### PR TITLE
Correctly reset n_initial_points on replace=True

### DIFF
--- a/bask/optimizer.py
+++ b/bask/optimizer.py
@@ -80,6 +80,7 @@ class Optimizer(object):
         if replace:
             self.Xi = []
             self.yi = []
+            self._n_initial_points = self.n_initial_points_
         if is_listlike(y) and is_2Dlistlike(x):
             self.Xi.extend(x)
             self.yi.extend(y)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -15,3 +15,16 @@ def test_multiple_asks():
     opt.ask()
     assert_equal(len(opt.Xi), 3)
     assert_equal(opt.ask(), opt.ask())
+
+
+def test_initial_points():
+    opt = Optimizer(dimensions=[(-2.0, 2.0)], n_initial_points=5)
+    x = opt.ask()
+    opt.tell([x], [0.])
+    assert opt._n_initial_points == opt.n_initial_points_ - 1
+
+    opt.tell([x], [0.])
+    assert opt._n_initial_points == opt.n_initial_points_ - 2
+
+    opt.tell([[0.1], [0.2], [0.3]], [0.0, 0.1, 0.2], replace=True)
+    assert opt._n_initial_points == opt.n_initial_points_ - 3


### PR DESCRIPTION
The internal counter `self._n_initial_points` was not reset, when the data points are replaced.
This commit fixes that and adds a test to prevent future problems of this kind.

Fixes #31 