### PR TITLE
Implement a wrapper for BayesSearchCV

### DIFF
--- a/bask/__init__.py
+++ b/bask/__init__.py
@@ -5,6 +5,7 @@ __email__ = "kiudee@mail.upb.de"
 __version__ = "0.2.0"
 
 from .acquisition import *
-from .bayesgpr import *
-from .optimizer import *
-from .utils import *
+from .bayesgpr import BayesGPR
+from .optimizer import Optimizer
+from .utils import geometric_median, guess_priors, construct_default_kernel, r2_sequence
+from .searchcv import BayesSearchCV

--- a/bask/bayesgpr.py
+++ b/bask/bayesgpr.py
@@ -330,4 +330,3 @@ class BayesGPR(GaussianProcessRegressor):
         self.alpha_ = current_alpha
         self.L_ = current_L
         return result
-

--- a/bask/bayesgpr.py
+++ b/bask/bayesgpr.py
@@ -219,7 +219,10 @@ class BayesGPR(GaussianProcessRegressor):
                     lp += prior(val)
             else:  # Assume priors is a callable, which evaluates the log probability:
                 lp += priors(x)
-            lp = lp + gp.log_marginal_likelihood(theta=x)
+            try:
+                lp = lp + gp.log_marginal_likelihood(theta=x)
+            except ValueError:
+                return -np.inf
             if not np.isfinite(lp):
                 return -np.inf
             return lp

--- a/bask/optimizer.py
+++ b/bask/optimizer.py
@@ -18,7 +18,7 @@ ACQUISITION_FUNC = {
     "pvrs": acquisition.PVRS(),
     "ts": acquisition.ThompsonSampling(),
     "ttei": acquisition.TopTwoEI(),
-    "vr": acquisition.VarianceReduction()
+    "vr": acquisition.VarianceReduction(),
 }
 
 
@@ -26,13 +26,13 @@ class Optimizer(object):
     def __init__(
         self,
         dimensions,
-        n_points=10000,
+        n_points=500,
         n_initial_points=10,
         init_strategy="r2",
         gp_kernel=None,
         gp_kwargs=None,
         gp_priors=None,
-        acq_func="mes",
+        acq_func="pvrs",
         acq_func_kwargs=None,
         random_state=None,
     ):
@@ -51,7 +51,9 @@ class Optimizer(object):
         self.n_initial_points_ = n_initial_points
         self.init_strategy = init_strategy
         if self.init_strategy == "r2":
-            self._initial_points = self.space.inverse_transform(r2_sequence(n=n_initial_points, d=self.space.n_dims))
+            self._initial_points = self.space.inverse_transform(
+                r2_sequence(n=n_initial_points, d=self.space.n_dims)
+            )
         self.n_points = n_points
 
         # TODO: Maybe a variant of cook estimator?
@@ -59,9 +61,17 @@ class Optimizer(object):
         if gp_kwargs is None:
             gp_kwargs = dict()
         if gp_kernel is None:
-            gp_kernel = construct_default_kernel(dimensions)
+            # For now the default kernel is not adapted to the dimensions,
+            # which is why a simple list is passed:
+            gp_kernel = construct_default_kernel(
+                list(range(self.space.transformed_n_dims))
+            )
 
-        self.gp = BayesGPR(kernel=gp_kernel, random_state=self.rng.randint(0, np.iinfo(np.int32).max), **gp_kwargs)
+        self.gp = BayesGPR(
+            kernel=gp_kernel,
+            random_state=self.rng.randint(0, np.iinfo(np.int32).max),
+            **gp_kwargs,
+        )
         # We are only able to guess priors now, since BayesGPR can add
         # another WhiteKernel, when noise is set to "gaussian":
         if gp_priors is None:
@@ -75,17 +85,34 @@ class Optimizer(object):
 
     def ask(self, n_points=1):
         if n_points > 1:
-            raise NotImplementedError("Returning multiple points is not implemented yet.")
-        if self._n_initial_points > 0:  # TODO: Make sure estimator is trained here always
+            raise NotImplementedError(
+                "Returning multiple points is not implemented yet."
+            )
+        if (
+            self._n_initial_points > 0
+        ):  # TODO: Make sure estimator is trained here always
             if self.init_strategy == "r2":
                 return self._initial_points[self._n_initial_points - 1]
             return self.space.rvs()
         else:
             if not self.gp.kernel_:
-                raise RuntimeError("Initialization is finished, but no model has been fit.")
+                raise RuntimeError(
+                    "Initialization is finished, but no model has been fit."
+                )
             return self._next_x
 
-    def tell(self, x, y, noise_vector=None, fit=True, replace=False, n_samples=5, gp_samples=100, gp_burnin=10, progress=False):
+    def tell(
+        self,
+        x,
+        y,
+        noise_vector=None,
+        fit=True,
+        replace=False,
+        n_samples=0,
+        gp_samples=100,
+        gp_burnin=10,
+        progress=False,
+    ):
         # if y isn't a scalar it means we have been handed a batch of points
 
         # TODO (noise vector):
@@ -103,7 +130,9 @@ class Optimizer(object):
             if noise_vector is None:
                 noise_vector = [0.0] * len(y)
             elif not is_listlike(noise_vector) or len(noise_vector) != len(y):
-                raise ValueError(f"Vector of noise variances needs to be of equal length as `y`.")
+                raise ValueError(
+                    f"Vector of noise variances needs to be of equal length as `y`."
+                )
             self.noisei.extend(noise_vector)
             self._n_initial_points -= len(y)
         elif is_listlike(x):
@@ -112,11 +141,16 @@ class Optimizer(object):
             if noise_vector is None:
                 noise_vector = 0.0
             elif is_listlike(noise_vector):
-                raise ValueError(f"Vector of noise variances is a list, while tell only received one datapoint.")
+                raise ValueError(
+                    f"Vector of noise variances is a list, while tell only received one datapoint."
+                )
             self.noisei.append(noise_vector)
             self._n_initial_points -= 1
         else:
-            raise ValueError(f"Type of arguments `x` ({type(x)}) and `y` ({type(y)}) " "not compatible.")
+            raise ValueError(
+                f"Type of arguments `x` ({type(x)}) and `y` ({type(y)}) "
+                "not compatible."
+            )
 
         if fit and self._n_initial_points <= 0:
             with warnings.catch_warnings():
@@ -139,10 +173,12 @@ class Optimizer(object):
                         priors=self.gp_priors,
                         n_desired_samples=gp_samples,
                         n_burnin=gp_burnin,
-                        progress=progress
+                        progress=progress,
                     )
 
-            X = self.space.transform(self.space.rvs(n_samples=self.n_points, random_state=self.rng))
+            X = self.space.transform(
+                self.space.rvs(n_samples=self.n_points, random_state=self.rng)
+            )
             acq_values = evaluate_acquisitions(
                 X=X,
                 gpr=self.gp,
@@ -153,7 +189,9 @@ class Optimizer(object):
                 **self.acq_func_kwargs,
             ).flatten()
 
-            self._next_x = self.space.inverse_transform(X[np.argmax(acq_values)].reshape((1, -1)))[0]
+            self._next_x = self.space.inverse_transform(
+                X[np.argmax(acq_values)].reshape((1, -1))
+            )[0]
 
         return create_result(self.Xi, self.yi, self.space, self.rng, models=[self.gp])
 

--- a/bask/searchcv.py
+++ b/bask/searchcv.py
@@ -344,7 +344,7 @@ class BayesSearchCV(BayesSearchCVSK):
         self.best_index_ = np.argmax(self.cv_results_["mean_test_score"])
 
         # feed the point and objective back into optimizer
-        local_results = self.cv_results_["mean_test_score"][-len(params) :]
+        local_results = self.cv_results_["mean_test_score"][-len(params):]
 
         # optimizer minimizes objective, hence provide negative score
         return optimizer.tell(

--- a/bask/searchcv.py
+++ b/bask/searchcv.py
@@ -53,9 +53,7 @@ class BayesSearchCV(BayesSearchCVSK):
         ``n_points`` if you want to try more parameter settings in
         parallel.
     optimizer_kwargs : dict, optional
-        Dict of arguments passed to :class:`Optimizer`.  For example,
-        ``{'base_estimator': 'RF'}`` would use a Random Forest surrogate
-        instead of the default Gaussian Process.
+        Dict of arguments passed to :class:`Optimizer`.
     scoring : string, callable or None, default=None
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature

--- a/bask/searchcv.py
+++ b/bask/searchcv.py
@@ -6,6 +6,230 @@ from bask.optimizer import Optimizer
 
 
 class BayesSearchCV(BayesSearchCVSK):
+    """Fully Bayesian optimization over hyper parameters.
+
+    Wraps skopt.BayesSearchCV with a fully Bayesian estimation of the
+    kernel hyperparameters, making it robust to very noisy target functions.
+
+    BayesSearchCV implements a "fit" and a "score" method.
+    It also implements "predict", "predict_proba", "decision_function",
+    "transform" and "inverse_transform" if they are implemented in the
+    estimator used.
+    The parameters of the estimator used to apply these methods are optimized
+    by cross-validated search over parameter settings.
+    In contrast to GridSearchCV, not all parameter values are tried out, but
+    rather a fixed number of parameter settings is sampled from the specified
+    distributions. The number of parameter settings that are tried is
+    given by n_iter.
+    Parameters are presented as a list of skopt.space.Dimension objects.
+    Parameters
+    ----------
+    estimator : estimator object.
+        A object of that type is instantiated for each search point.
+        This object is assumed to implement the scikit-learn estimator api.
+        Either estimator needs to provide a ``score`` function,
+        or ``scoring`` must be passed.
+    search_spaces : dict, list of dict or list of tuple containing
+        (dict, int).
+        One of these cases:
+        1. dictionary, where keys are parameter names (strings)
+        and values are skopt.space.Dimension instances (Real, Integer
+        or Categorical) or any other valid value that defines skopt
+        dimension (see skopt.Optimizer docs). Represents search space
+        over parameters of the provided estimator.
+        2. list of dictionaries: a list of dictionaries, where every
+        dictionary fits the description given in case 1 above.
+        If a list of dictionary objects is given, then the search is
+        performed sequentially for every parameter space with maximum
+        number of evaluations set to self.n_iter.
+        3. list of (dict, int > 0): an extension of case 2 above,
+        where first element of every tuple is a dictionary representing
+        some search subspace, similarly as in case 2, and second element
+        is a number of iterations that will be spent optimizing over
+        this subspace.
+    n_iter : int, default=50
+        Number of parameter settings that are sampled. n_iter trades
+        off runtime vs quality of the solution. Consider increasing
+        ``n_points`` if you want to try more parameter settings in
+        parallel.
+    optimizer_kwargs : dict, optional
+        Dict of arguments passed to :class:`Optimizer`.  For example,
+        ``{'base_estimator': 'RF'}`` would use a Random Forest surrogate
+        instead of the default Gaussian Process.
+    scoring : string, callable or None, default=None
+        A string (see model evaluation documentation) or
+        a scorer callable object / function with signature
+        ``scorer(estimator, X, y)``.
+        If ``None``, the ``score`` method of the estimator is used.
+    fit_params : dict, optional
+        Parameters to pass to the fit method.
+    n_jobs : int, default=1
+        Number of jobs to run in parallel. At maximum there are
+        ``n_points`` times ``cv`` jobs available during each iteration.
+    n_points : int, default=1
+        This is not implemented yet. Consider using the original
+        skopt.BayesSearchCV for now.
+        Number of parameter settings to sample in parallel. If this does
+        not align with ``n_iter``, the last iteration will sample less
+        points. See also :func:`~Optimizer.ask`
+    pre_dispatch : int, or string, optional
+        Controls the number of jobs that get dispatched during parallel
+        execution. Reducing this number can be useful to avoid an
+        explosion of memory consumption when more jobs get dispatched
+        than CPUs can process. This parameter can be:
+            - None, in which case all the jobs are immediately
+              created and spawned. Use this for lightweight and
+              fast-running jobs, to avoid delays due to on-demand
+              spawning of the jobs
+            - An int, giving the exact number of total jobs that are
+              spawned
+            - A string, giving an expression as a function of n_jobs,
+              as in '2*n_jobs'
+    iid : boolean, default=True
+        If True, the data is assumed to be identically distributed across
+        the folds, and the loss minimized is the total loss per sample,
+        and not the mean loss across the folds.
+    cv : int, cross-validation generator or an iterable, optional
+        Determines the cross-validation splitting strategy.
+        Possible inputs for cv are:
+          - None, to use the default 3-fold cross validation,
+          - integer, to specify the number of folds in a `(Stratified)KFold`,
+          - An object to be used as a cross-validation generator.
+          - An iterable yielding train, test splits.
+        For integer/None inputs, if the estimator is a classifier and ``y`` is
+        either binary or multiclass, :class:`StratifiedKFold` is used. In all
+        other cases, :class:`KFold` is used.
+    refit : boolean, default=True
+        Refit the best estimator with the entire dataset.
+        If "False", it is impossible to make predictions using
+        this RandomizedSearchCV instance after fitting.
+    verbose : integer
+        Controls the verbosity: the higher, the more messages.
+    random_state : int or RandomState
+        Pseudo random number generator state used for random uniform sampling
+        from lists of possible values instead of scipy.stats distributions.
+    error_score : 'raise' (default) or numeric
+        Value to assign to the score if an error occurs in estimator fitting.
+        If set to 'raise', the error is raised. If a numeric value is given,
+        FitFailedWarning is raised. This parameter does not affect the refit
+        step, which will always raise the error.
+    return_train_score : boolean, default=False
+        If ``'True'``, the ``cv_results_`` attribute will include training
+        scores.
+    Examples
+    --------
+    >>> from skopt import BayesSearchCV
+    >>> # parameter ranges are specified by one of below
+    >>> from skopt.space import Real, Categorical, Integer
+    >>>
+    >>> from sklearn.datasets import load_iris
+    >>> from sklearn.svm import SVC
+    >>> from sklearn.model_selection import train_test_split
+    >>>
+    >>> X, y = load_iris(True)
+    >>> X_train, X_test, y_train, y_test = train_test_split(X, y,
+    ...                                                     train_size=0.75,
+    ...                                                     random_state=0)
+    >>>
+    >>> # log-uniform: understand as search over p = exp(x) by varying x
+    >>> opt = BayesSearchCV(
+    ...     SVC(),
+    ...     {
+    ...         'C': Real(1e-6, 1e+6, prior='log-uniform'),
+    ...         'gamma': Real(1e-6, 1e+1, prior='log-uniform'),
+    ...         'degree': Integer(1,8),
+    ...         'kernel': Categorical(['linear', 'poly', 'rbf']),
+    ...     },
+    ...     n_iter=32,
+    ...     random_state=0
+    ... )
+    >>>
+    >>> # executes bayesian optimization
+    >>> _ = opt.fit(X_train, y_train)
+    >>>
+    >>> # model can be saved, used for predictions or scoring
+    >>> print(opt.score(X_test, y_test))
+    0.973...
+    Attributes
+    ----------
+    cv_results_ : dict of numpy (masked) ndarrays
+        A dict with keys as column headers and values as columns, that can be
+        imported into a pandas ``DataFrame``.
+        For instance the below given table
+        +--------------+-------------+-------------------+---+---------------+
+        | param_kernel | param_gamma | split0_test_score |...|rank_test_score|
+        +==============+=============+===================+===+===============+
+        |    'rbf'     |     0.1     |        0.8        |...|       2       |
+        +--------------+-------------+-------------------+---+---------------+
+        |    'rbf'     |     0.2     |        0.9        |...|       1       |
+        +--------------+-------------+-------------------+---+---------------+
+        |    'rbf'     |     0.3     |        0.7        |...|       1       |
+        +--------------+-------------+-------------------+---+---------------+
+        will be represented by a ``cv_results_`` dict of::
+            {
+            'param_kernel' : masked_array(data = ['rbf', 'rbf', 'rbf'],
+                                          mask = False),
+            'param_gamma'  : masked_array(data = [0.1 0.2 0.3], mask = False),
+            'split0_test_score'  : [0.8, 0.9, 0.7],
+            'split1_test_score'  : [0.82, 0.5, 0.7],
+            'mean_test_score'    : [0.81, 0.7, 0.7],
+            'std_test_score'     : [0.02, 0.2, 0.],
+            'rank_test_score'    : [3, 1, 1],
+            'split0_train_score' : [0.8, 0.9, 0.7],
+            'split1_train_score' : [0.82, 0.5, 0.7],
+            'mean_train_score'   : [0.81, 0.7, 0.7],
+            'std_train_score'    : [0.03, 0.03, 0.04],
+            'mean_fit_time'      : [0.73, 0.63, 0.43, 0.49],
+            'std_fit_time'       : [0.01, 0.02, 0.01, 0.01],
+            'mean_score_time'    : [0.007, 0.06, 0.04, 0.04],
+            'std_score_time'     : [0.001, 0.002, 0.003, 0.005],
+            'params' : [{'kernel' : 'rbf', 'gamma' : 0.1}, ...],
+            }
+        NOTE that the key ``'params'`` is used to store a list of parameter
+        settings dict for all the parameter candidates.
+        The ``mean_fit_time``, ``std_fit_time``, ``mean_score_time`` and
+        ``std_score_time`` are all in seconds.
+    best_estimator_ : estimator
+        Estimator that was chosen by the search, i.e. estimator
+        which gave highest score (or smallest loss if specified)
+        on the left out data. Not available if refit=False.
+    optimizer_results_ : list of `OptimizeResult`
+        Contains a `OptimizeResult` for each search space. The search space
+        parameter are sorted by its name.
+    best_score_ : float
+        Score of best_estimator on the left out data.
+    best_params_ : dict
+        Parameter setting that gave the best results on the hold out data.
+    best_index_ : int
+        The index (of the ``cv_results_`` arrays) which corresponds to the best
+        candidate parameter setting.
+        The dict at ``search.cv_results_['params'][search.best_index_]`` gives
+        the parameter setting for the best model, that gives the highest
+        mean score (``search.best_score_``).
+    scorer_ : function
+        Scorer function used on the held out data to choose the best
+        parameters for the model.
+    n_splits_ : int
+        The number of cross-validation splits (folds/iterations).
+    Notes
+    -----
+    The parameters selected are those that maximize the score of the held-out
+    data, according to the scoring parameter.
+    If `n_jobs` was set to a value higher than one, the data is copied for each
+    parameter setting(and not `n_jobs` times). This is done for efficiency
+    reasons if individual jobs take very little time, but may raise errors if
+    the dataset is large and not enough memory is available.  A workaround in
+    this case is to set `pre_dispatch`. Then, the memory is copied only
+    `pre_dispatch` many times. A reasonable value for `pre_dispatch` is `2 *
+    n_jobs`.
+    See Also
+    --------
+    :class:`skopt.BayesSearchCV`:
+        This class wraps the original BayesSearchCV in skopt.
+    :class:`GridSearchCV`:
+        Does exhaustive search over a grid of parameters.
+    """
+
     def __init__(
         self,
         estimator,
@@ -67,14 +291,13 @@ class BayesSearchCV(BayesSearchCVSK):
 
         """
         kwargs = self.optimizer_kwargs_.copy()
-        kwargs['dimensions'] = dimensions_aslist(params_space)
+        kwargs["dimensions"] = dimensions_aslist(params_space)
         # Here we replace skopt's Optimizer:
         optimizer = Optimizer(**kwargs)
         for i in range(len(optimizer.space.dimensions)):
             if optimizer.space.dimensions[i].name is not None:
                 continue
-            optimizer.space.dimensions[i].name = list(sorted(
-                params_space.keys()))[i]
+            optimizer.space.dimensions[i].name = list(sorted(params_space.keys()))[i]
 
         return optimizer
 
@@ -123,7 +346,7 @@ class BayesSearchCV(BayesSearchCVSK):
         self.best_index_ = np.argmax(self.cv_results_["mean_test_score"])
 
         # feed the point and objective back into optimizer
-        local_results = self.cv_results_["mean_test_score"][-len(params):]
+        local_results = self.cv_results_["mean_test_score"][-len(params) :]
 
         # optimizer minimizes objective, hence provide negative score
         return optimizer.tell(

--- a/bask/searchcv.py
+++ b/bask/searchcv.py
@@ -1,0 +1,136 @@
+import numpy as np
+from scipy.stats import rankdata
+from skopt import BayesSearchCV as BayesSearchCVSK
+from skopt.utils import point_asdict, dimensions_aslist
+from bask.optimizer import Optimizer
+
+
+class BayesSearchCV(BayesSearchCVSK):
+    def __init__(
+        self,
+        estimator,
+        search_spaces,
+        optimizer_kwargs=None,
+        n_iter=50,
+        scoring=None,
+        fit_params=None,
+        n_jobs=1,
+        n_points=1,
+        iid=True,
+        refit=True,
+        cv=None,
+        verbose=0,
+        pre_dispatch="2*n_jobs",
+        random_state=None,
+        error_score="raise",
+        return_train_score=False,
+    ):
+        super().__init__(
+            estimator,
+            search_spaces,
+            optimizer_kwargs,
+            n_iter,
+            scoring,
+            fit_params,
+            n_jobs,
+            n_points,
+            iid,
+            refit,
+            cv,
+            verbose,
+            pre_dispatch,
+            random_state,
+            error_score,
+            return_train_score,
+        )
+        if self.optimizer_kwargs is None:
+            self.optimizer_kwargs = {}
+        self.n_samples = self.optimizer_kwargs.get("n_samples", 0)
+        self.gp_samples = self.optimizer_kwargs.get("gp_samples", 100)
+        self.gp_burnin = self.optimizer_kwargs.get("gp_burnin", 5)
+        if "acq_func" not in self.optimizer_kwargs:
+            self.optimizer_kwargs["acq_func"] = "pvrs"
+
+    def _make_optimizer(self, params_space):
+        """Instantiate bask Optimizer class.
+
+        Parameters
+        ----------
+        params_space : dict
+            Represents parameter search space. The keys are parameter
+            names (strings) and values are skopt.space.Dimension instances,
+            one of Real, Integer or Categorical.
+        Returns
+        -------
+        optimizer: Instance of the `Optimizer` class used for for search
+            in some parameter space.
+
+        """
+        kwargs = self.optimizer_kwargs_.copy()
+        kwargs['dimensions'] = dimensions_aslist(params_space)
+        # Here we replace skopt's Optimizer:
+        optimizer = Optimizer(**kwargs)
+        for i in range(len(optimizer.space.dimensions)):
+            if optimizer.space.dimensions[i].name is not None:
+                continue
+            optimizer.space.dimensions[i].name = list(sorted(
+                params_space.keys()))[i]
+
+        return optimizer
+
+    def _step(self, X, y, search_space, optimizer, groups=None, n_points=1):
+        """Generate n_jobs parameters and evaluate them in parallel."""
+
+        # get parameter values to evaluate
+        # TODO: Until n_points is supported, we will wrap the return value in a list
+        params = [optimizer.ask(n_points=n_points)]
+
+        # convert parameters to python native types
+        params = [[np.array(v).item() for v in p] for p in params]
+
+        # make lists into dictionaries
+        params_dict = [point_asdict(search_space, p) for p in params]
+
+        # HACK: self.cv_results_ is reset at every call to _fit, keep current
+        all_cv_results = self.cv_results_
+
+        # HACK: this adds compatibility with different versions of sklearn
+        refit = self.refit
+        self.refit = False
+        self._fit(X, y, groups, params_dict)
+        self.refit = refit
+
+        # merge existing and new cv_results_
+        for k in self.cv_results_:
+            all_cv_results[k].extend(self.cv_results_[k])
+
+        all_cv_results["rank_test_score"] = list(
+            np.asarray(
+                rankdata(-np.array(all_cv_results["mean_test_score"]), method="min"),
+                dtype=np.int32,
+            )
+        )
+        if self.return_train_score:
+            all_cv_results["rank_train_score"] = list(
+                np.asarray(
+                    rankdata(
+                        -np.array(all_cv_results["mean_train_score"]), method="min"
+                    ),
+                    dtype=np.int32,
+                )
+            )
+        self.cv_results_ = all_cv_results
+        self.best_index_ = np.argmax(self.cv_results_["mean_test_score"])
+
+        # feed the point and objective back into optimizer
+        local_results = self.cv_results_["mean_test_score"][-len(params):]
+
+        # optimizer minimizes objective, hence provide negative score
+        return optimizer.tell(
+            params,
+            [-score for score in local_results],
+            n_samples=self.n_samples,
+            gp_samples=self.gp_samples,
+            gp_burnin=self.gp_burnin,
+            progress=False,
+        )

--- a/bask/utils.py
+++ b/bask/utils.py
@@ -4,7 +4,12 @@ from scipy.stats import halfnorm, invgamma
 from skopt.learning.gaussian_process.kernels import Matern, ConstantKernel
 
 
-__all__ = ["geometric_median", "r2_sequence", "guess_priors"]
+__all__ = [
+    "geometric_median",
+    "r2_sequence",
+    "guess_priors",
+    "construct_default_kernel",
+]
 
 
 def geometric_median(X, eps=1e-5):

--- a/bask/utils.py
+++ b/bask/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scipy.spatial.distance import cdist, euclidean
 from scipy.stats import halfnorm, invgamma
+from skopt.learning.gaussian_process.kernels import Matern, ConstantKernel
 
 
 __all__ = ["geometric_median", "r2_sequence", "guess_priors"]
@@ -53,10 +54,94 @@ def geometric_median(X, eps=1e-5):
         y = y1
 
 
-def guess_priors(n_parameters):
-    priors = [lambda x: halfnorm(scale=2.0).logpdf(np.sqrt(np.exp(x))) + x / 2.0 - np.log(2.0)]
-    priors.extend([lambda x: invgamma(a=8.92, scale=1.73).logpdf(np.exp(x)) + x for _ in range(n_parameters)])
-    priors.append(lambda x: halfnorm(scale=1.0).logpdf(np.sqrt(np.exp(x))) + x / 2.0 - np.log(2.0))
+def _recursive_priors(kernel, prior_list):
+    if hasattr(kernel, "kernel"):  # Unary operations
+        _recursive_priors(kernel.kernel, prior_list)
+    elif hasattr(kernel, "k1"):  # Binary operations
+        _recursive_priors(kernel.k1, prior_list)
+        _recursive_priors(kernel.k2, prior_list)
+    elif hasattr(kernel, "kernels"):  # CompoundKernel
+        for k in kernel.kernels:
+            _recursive_priors(k, prior_list)
+    else:
+        name = type(kernel).__name__
+        if name in ["ConstantKernel", "WhiteKernel"]:
+            # We use a half-normal prior distribution on the signal variance and
+            # noise. The input x is sampled in log-space, which is why the
+            # change of variables is necessary.
+            # This prior assumes that the function values are standardized.
+            # Note, that we do not know the structure of the kernel, which is
+            # why this is just only a best guess.
+            prior_list.append(
+                lambda x: halfnorm(scale=2.0).logpdf(np.sqrt(np.exp(x)))
+                + x / 2.0
+                - np.log(2.0),
+            )
+        elif name in ["Matern", "RBF"]:
+            # Here we apply an inverse gamma distribution to any lengthscale
+            # parameter we find. We assume the input variables are normalized
+            # to lie in [0, 1]. The specific values for a and scale were
+            # obtained by fitting the 1% and 99% quantile to 0.15 and 0.8.
+            prior_list.append(
+                lambda x: invgamma(a=8.286, scale=2.4605).logpdf(np.exp(x)) + x,
+            )
+        else:
+            raise NotImplementedError(
+                f"Unable to guess priors for this kernel: {kernel}."
+            )
+
+
+def construct_default_kernel(dimensions):
+    """Construct a Matern kernel as default kernel to be used in the optimizer.
+
+    Parameters
+    ----------
+    dimensions : list of dimensions
+        Elements are skopt.space.Dimension instances (Real, Integer
+        or Categorical) or any other valid value that defines skopt
+        dimension (see skopt.Optimizer docs)
+
+    Returns
+    -------
+    kernel : kernel object
+        The kernel specifying the covariance function of the GP used in the
+        optimization.
+    """
+    n_parameters = len(dimensions)
+    kernel = ConstantKernel(
+        constant_value=1.0, constant_value_bounds=(0.1, 2.0)
+    ) * Matern(
+        length_scale=[0.3] * n_parameters, length_scale_bounds=(0.05, 1.0), nu=2.5
+    )
+    return kernel
+
+
+def guess_priors(kernel):
+    """Guess suitable priors for the hyperparameters of a given kernel.
+
+    This function recursively explores the given (composite) kernel and
+    adds suitable priors each encountered hyperparameter.
+
+    Here we use a half-Normal(0, 2.0) prior for all ConstantKernels and
+    WhiteKernels, and an invGamma(a=8.286, scale=2.4605) prior for all
+    lengthscales. Change of variables is applied, since inference is done in
+    log-space.
+
+    Parameters
+    ----------
+    kernel : Kernel object.
+        Can be a single kernel (e.g. Matern), a Product or Sum kernel, or a
+        CompoundKernel.
+
+    Returns
+    -------
+    priors : list of functions.
+        The function returns the list of priors in the same order as the vector
+        theta provided by the kernel. Each prior evaluates the logpdf of its
+        argument.
+    """
+    priors = []
+    _recursive_priors(kernel, priors)
     return priors
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ requirements = [
     "scikit-learn",
     "matplotlib",
     "emcee",
+    "tqdm"
 ]
 
 setup_requirements = [

--- a/tests/test_searchcv.py
+++ b/tests/test_searchcv.py
@@ -1,0 +1,27 @@
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+from sklearn.svm import SVC
+from skopt.space import Real, Categorical, Integer
+from bask.searchcv import BayesSearchCV
+
+
+def test_searchcv_run():
+    X, y = load_iris(True)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, train_size=0.75, random_state=0
+    )
+
+    opt = BayesSearchCV(
+        SVC(),
+        {
+            "C": Real(1e-6, 1e6, prior="log-uniform"),
+            "gamma": Real(1e-6, 1e1, prior="log-uniform"),
+            "degree": Integer(1, 8),
+            "kernel": Categorical(["linear", "poly", "rbf"]),
+        },
+        n_iter=11,
+        cv=None,
+    )
+
+    opt.fit(X_train, y_train)
+    assert opt.score(X_test, y_test) > 0.9

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+from numpy.testing import assert_almost_equal
+from sklearn.gaussian_process.kernels import CompoundKernel
+from skopt.learning.gaussian_process.kernels import (
+    ExpSineSquared,
+    Matern,
+    ConstantKernel,
+    WhiteKernel,
+    Exponentiation,
+    DotProduct,
+    Product,
+    RationalQuadratic,
+    RBF,
+)
+from bask.utils import guess_priors, construct_default_kernel
+
+
+def test_construct_default_kernel():
+    kernel = construct_default_kernel([0, 1])
+    assert len(kernel.theta) == 3
+
+
+def test_guess_priors():
+    """Construct a complicated kernel and check if priors are constructed
+    correctly."""
+    kernel = Exponentiation(
+        ConstantKernel(constant_value_bounds="fixed") * Matern()
+        + WhiteKernel()
+        + CompoundKernel([RBF(), Matern()]),
+        2.0,
+    )
+
+    priors = guess_priors(kernel)
+
+    assert len(priors) == 4
+    expected = [
+        -1.737085713764618,
+        -4.107091211892862,
+        -1.737085713764618,
+        -1.737085713764618,
+    ]
+    for p, v in zip(priors, expected):
+        assert_almost_equal(p(0.0), v)


### PR DESCRIPTION
For users of [scikit-learn](https://scikit-learn.org/stable/) the usage of `GridSearchCV` and `RandomSearchCV` is very convenient, since it allows the optimization of complete pipelines. [scikit-optimize](https://github.com/scikit-optimize/scikit-optimize) implements `BayesSearchCV`, which allows users to wrap arbitrary sklearn-style estimators.

It is straightforward to implement `BayesSearchCV` in bask and only a few adjustments need to be made.

TODO
----

- [x] Implement more general `guess_priors` function.
- [x] Implement default kernel
- [x] Better default parameters to be faster when used in BayesSearchCV
- [x] Implement BayesSearchCV wrapper with necessary modifications
- [x] Document BayesSearchCV wrapper
- [x] Implement a simple test