### PR TITLE
Raise exception when user tries to call gp.sample without data

### DIFF
--- a/tests/test_bayesgpr.py
+++ b/tests/test_bayesgpr.py
@@ -44,3 +44,9 @@ def test_noise_set_to_zero(minimal_gp, minimal_priors):
     assert minimal_gp.predict(np.array([[0.0]]), return_std=True)[1] >= 1.0
 
 
+def test_sample_without_fit(minimal_gp):
+    # Calling sample without data (X, y) or a previous fit, should raise a ValueError:
+    with pytest.raises(ValueError):
+        minimal_gp.sample()
+
+


### PR DESCRIPTION
Currently, users receive an obscure error which is not very helpful in diagnosing what the problem is. This pull request raises an exception immediately and includes a helpful error message to point the user in the right direction.