### PR TITLE
Fix error occuring when optimizer is called with unknown argument

### DIFF
--- a/bask/optimizer.py
+++ b/bask/optimizer.py
@@ -108,6 +108,7 @@ class Optimizer(object):
         acq_func="pvrs",
         acq_func_kwargs=None,
         random_state=None,
+        **kwargs
     ):
         self.rng = check_random_state(random_state)
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -47,3 +47,7 @@ def test_noise_vector():
     # Check, if passing a single point works correctly:
     x = opt.ask()
     opt.tell(x, 0.0, noise_vector=0.5)
+
+
+def test_no_error_on_unknown_kwargs():
+    opt = Optimizer(dimensions=[(-2.0, 2.0)], n_initial_points=5, unknown_argument=42)


### PR DESCRIPTION
This error can happen, when BayesSearchCV is called with optimizer_kwargs containing
parameters to be used for the fit call. Example:
https://github.com/kiudee/bayes-skopt/blob/d91d354bf0b63b40cc3cd7e80b7ae6b2f1b2233e/bask/searchcv.py#L270-L272