### PR TITLE
Add return policy to BayesSearchCV

### DIFF
--- a/bask/searchcv.py
+++ b/bask/searchcv.py
@@ -331,11 +331,11 @@ class BayesSearchCV(BayesSearchCVSK):
             random_state = self.optimizer_kwargs_["random_state"]
             # We construct a result object manually here, since in skopt versions up to 0.7.4 they were not saved yet:
             opt = self.optimizers_[0]
-            result_object = create_result(opt.Xi, opt.yi, space=opt.space, rng=random_state, models=[opt.gp])
+            result_object = create_result(
+                opt.Xi, opt.yi, space=opt.space, rng=random_state, models=[opt.gp]
+            )
             point, _ = expected_minimum(
-                res=result_object,
-                n_random_starts=100,
-                random_state=random_state,
+                res=result_object, n_random_starts=100, random_state=random_state,
             )
             dict = point_asdict(self.search_spaces, point)
             return dict

--- a/bask/searchcv.py
+++ b/bask/searchcv.py
@@ -116,7 +116,7 @@ class BayesSearchCV(BayesSearchCVSK):
         scores.
     Examples
     --------
-    >>> from skopt import BayesSearchCV
+    >>> from bask import BayesSearchCV
     >>> # parameter ranges are specified by one of below
     >>> from skopt.space import Real, Categorical, Integer
     >>>

--- a/bask/searchcv.py
+++ b/bask/searchcv.py
@@ -1,9 +1,14 @@
 import logging
+
 import numpy as np
 from scipy.stats import rankdata
 from sklearn.utils.validation import check_is_fitted
 from skopt import BayesSearchCV as BayesSearchCVSK
-from skopt.utils import point_asdict, dimensions_aslist, expected_minimum, create_result
+from skopt.utils import create_result
+from skopt.utils import dimensions_aslist
+from skopt.utils import expected_minimum
+from skopt.utils import point_asdict
+
 from bask.optimizer import Optimizer
 
 

--- a/tests/test_searchcv.py
+++ b/tests/test_searchcv.py
@@ -43,7 +43,7 @@ def test_searchcv_best_mean():
         },
         n_iter=11,
         cv=None,
-        return_policy="best_mean"
+        return_policy="best_mean",
     )
 
     opt.fit(X_train, y_train)

--- a/tests/test_searchcv.py
+++ b/tests/test_searchcv.py
@@ -1,7 +1,10 @@
 from sklearn.datasets import load_iris
 from sklearn.model_selection import train_test_split
 from sklearn.svm import SVC
-from skopt.space import Real, Categorical, Integer
+from skopt.space import Categorical
+from skopt.space import Integer
+from skopt.space import Real
+
 from bask.searchcv import BayesSearchCV
 
 

--- a/tests/test_searchcv.py
+++ b/tests/test_searchcv.py
@@ -25,3 +25,26 @@ def test_searchcv_run():
 
     opt.fit(X_train, y_train)
     assert opt.score(X_test, y_test) > 0.9
+
+
+def test_searchcv_best_mean():
+    X, y = load_iris(True)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, train_size=0.75, random_state=0
+    )
+
+    opt = BayesSearchCV(
+        SVC(),
+        {
+            "C": Real(1e-6, 1e6, prior="log-uniform"),
+            "gamma": Real(1e-6, 1e1, prior="log-uniform"),
+            "degree": Integer(1, 8),
+            "kernel": Categorical(["linear", "poly", "rbf"]),
+        },
+        n_iter=11,
+        cv=None,
+        return_policy="best_mean"
+    )
+
+    opt.fit(X_train, y_train)
+    assert opt.score(X_test, y_test) > 0.9


### PR DESCRIPTION
By default BayesSearchCV returns the parameter configuration which performed best during validation. This is fine for experiments with fixed random seeds and no noise in the system. This is of course inadequate if the validation performance is noisy.

This pull requests adds the `return_policy` parameter to BayesSearchCV with the following possible values:

 * "best_setting" is the current default option and returns the best performing
   configuration tested during the optimization.
 * "best_mean" will compute the global optimum of the Gaussian process
   surrogate model and should work better for noisy target functions.