### PR TITLE
Restrict scikit-learn to version 0.18.2 to 0.22.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     "scikit-optimize",
     "numpy",
     "scipy",
-    "scikit-learn",
+    "scikit-learn>=0.18.2,<0.23",
     "matplotlib",
     "emcee",
     "tqdm"


### PR DESCRIPTION
We depend on scikit-optimize, which uses MaskedArray from scikit-learn.
0.23 broke compatibility, which is why the dependency is temporarily restricted.