### PR TITLE
Use official emcee interface to access MCMC chain

### DIFF
--- a/bask/bayesgpr.py
+++ b/bask/bayesgpr.py
@@ -214,6 +214,7 @@ class BayesGPR(GaussianProcessRegressor):
         n_threads=1,
         n_desired_samples=100,
         n_burnin=0,
+        n_thin=1,
         n_walkers_per_thread=100,
         progress=False,
         priors=None,
@@ -291,7 +292,7 @@ class BayesGPR(GaussianProcessRegressor):
         # if backup_file is not None:
         #     with open(backup_file, "wb") as f:
         #         np.save(f, pos)
-        chain = self._sampler.chain[:, n_burnin:, :].reshape(-1, n_dim)
+        chain = self._sampler.get_chain(flat=True, discard=n_burnin, thin=n_thin)
         if add and self.chain_ is not None:
             self.chain_ = np.concatenate([self.chain_, chain])
         else:

--- a/bask/bayesgpr.py
+++ b/bask/bayesgpr.py
@@ -222,6 +222,7 @@ class BayesGPR(GaussianProcessRegressor):
         add=False,
         **kwargs
     ):
+        """ Sample from the posterior distribution of the hyper-parameters."""
         def log_prob_fn(x, gp=self):
             lp = 0
             if isinstance(priors, Iterable):


### PR DESCRIPTION
The existing code does access the `emcee.EnsembleSampler.chain` attribute and does manual reshaping of the chain. This is error prone and might break in the future.
Using the `get_chain` method instead has the added advantage, that concatenating posterior samples several times with a subsequent reshape restores the original emcee walkers.