### PR TITLE
Implement probability of optimality

### DIFF
--- a/bask/optimizer.py
+++ b/bask/optimizer.py
@@ -290,6 +290,32 @@ class Optimizer(object):
         use_mean_gp=True,
         random_state=None,
     ):
+        """ Compute the probability that the current expected optimum cannot be improved by more than ``threshold``
+        points.
+
+        Parameters
+        ----------
+        threshold : float or list-of-floats
+            Other points have to be better than the current optimum by at least a margin of size ``threshold``.
+            If a list is passed, this will return a list of probabilities.
+        n_space_samples : int, default=500
+            Number of random samples used to cover the optimization space.
+        n_gp_samples : int, default=200
+            Number of functions to sample from the Gaussian process.
+        n_random_starts : int, default=100
+            Number of random positions to start the optimizer from in order to determine the global optimum.
+        use_mean_gp : bool, default=True
+            If True, random functions will be sampled from the consensus GP, which is usually faster, but could
+            underestimate the variability. If False, the posterior distribution over hyperparameters is used to sample
+            different GPs and then sample functions.
+        random_state : int, RandomState instance, or None (default)
+            Set random state to something other than None for reproducible results.
+
+        Returns
+        -------
+        probabilities : float or list-of-floats
+            Probabilities of the current optimum to be optimal wrt the given thresholds.
+        """
         result = create_result(self.Xi, self.yi, self.space, self.rng, models=[self.gp])
         X_orig = [
             expected_minimum(

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -71,4 +71,4 @@ def test_probability_of_improvement(random_state):
     np.testing.assert_almost_equal(prob, 0.995)
 
     prob = opt.probability_of_optimality(threshold=[0.9, 0.5], n_random_starts=20, random_state=random_state)
-    np.testing.assert_almost_equal(prob, [0.925, 0.765])
+    np.testing.assert_almost_equal(prob, [0.925, 0.765], decimal=1)


### PR DESCRIPTION
Currently, it is hard to gauge, how good the optimum is which has been found so far.
This makes it hard to decide when to terminate an optimization run.

This pull request implements `Optimizer.probability_of_optimality(...)` to which a user can pass a `threshold`. The method will repeatedly sample functions from the GP model. If another point in the optimization space improves over the current optimum by more than `threshold`, we consider the current optimum to not be optimal. The average frequency we call the probability of optimality.

Closes #61 
