### PR TITLE
Check if length of list of priors is correct

### DIFF
--- a/bask/optimizer.py
+++ b/bask/optimizer.py
@@ -156,6 +156,8 @@ class Optimizer(object):
         # another WhiteKernel, when noise is set to "gaussian":
         if gp_priors is None:
             gp_priors = guess_priors(self.gp.kernel)
+        elif len(gp_priors) != self.space.transformed_n_dims + 2:
+            raise ValueError("The number of priors does not match the number of dimensions + 2.")
         self.gp_priors = gp_priors
 
         self.Xi = []

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -60,6 +60,11 @@ def test_no_error_on_unknown_kwargs():
     opt = Optimizer(dimensions=[(-2.0, 2.0)], n_initial_points=5, unknown_argument=42)
 
 
+def test_error_on_invalid_priors():
+    with pytest.raises(ValueError):
+        Optimizer(dimensions=[(-2.0, 2.0)], gp_priors=[])
+
+
 def test_probability_of_improvement(random_state):
     opt = Optimizer(
         dimensions=[(-2.0, 2.0)], n_initial_points=0, random_state=random_state


### PR DESCRIPTION
It can quickly happen due to copy/paste errors that a user passes an incorrect amount of prior distributions. This pull request adds a simple check to prevent that.

Fixes #57