### PR TITLE
Improve default priors for lengthscale parameters

### DIFF
--- a/bask/optimizer.py
+++ b/bask/optimizer.py
@@ -62,6 +62,12 @@ class Optimizer(object):
         Dict of arguments passed to :class:`BayesGPR`.  For example,
         ``{'normalize_y': True}`` would allow the GP to normalize the output
         values before fitting.
+    gp_priors : list of callables, optional
+        List of prior distributions for the kernel hyperparameters of the GP.
+        Each callable returns the logpdf of the prior distribution.
+        Remember that a WhiteKernel is added to the ``gp_kernel``, which is why
+        you need to include a prior distribution for that as well.
+        If None, will try to guess suitable prior distributions.
     acq_func : string or Acquisition object, default="pvrs"
         Acquisition function to use as a criterion to select new points to test.
         By default we use "pvrs", which is a very robust criterion with fast

--- a/bask/priors.py
+++ b/bask/priors.py
@@ -1,0 +1,52 @@
+import numpy as np
+from scipy.integrate import quad
+
+__all__ = ["make_roundflat"]
+
+
+def make_roundflat(
+    lower_bound=0.1,
+    upper_bound=0.6,
+    lower_steepness=2.0,
+    upper_steepness=8.0,
+    integration_bounds=(0.0, 10.0),
+):
+    """Construct a round-flat prior with a certain shape.
+
+    The resulting prior is roughly flat inside the range
+    (lower_bound, upper_bound)
+    and the density drops smoothly the closer points are to the bounds.
+
+    Parameters
+    ----------
+    lower_bound : float, default=0.1
+        Number which specifies the lower bound of the plausible range.
+    upper_bound : float, default=0.6
+        Number which specifies the upper bound of the plausible range.
+    lower_steepness : float, default=2.0
+        Exponent which controls how steep the prior falls off when approaching
+        the lower bound. Higher values result in a steeper drop.
+    upper_steepness : float, default=8.0
+        Exponent which controls how steep the prior falls off when approaching
+        the upper bound. Higher values result in a steeper drop.
+    integration_bounds : tuple of floats, default=(0.0, 10.0)
+        The lower and upper bound of the range in which to integrate the prior.
+        This is used to normalize the prior.
+    Returns
+    -------
+    prior : function
+        Prior distribution which for a given x returns the log density at that
+        point.
+    """
+
+    def roundflat(x):
+        return -2 * (
+            (x / lower_bound) ** (-2 * lower_steepness)
+            + (x / upper_bound) ** (2 * upper_steepness)
+        )
+
+    value = quad(
+        lambda x: np.exp(roundflat(x)), integration_bounds[0], integration_bounds[1]
+    )[0]
+    prior = lambda x: roundflat(x) - np.log(value)
+    return prior

--- a/bask/utils.py
+++ b/bask/utils.py
@@ -68,11 +68,17 @@ def _recursive_priors(kernel, prior_list):
         _recursive_priors(kernel.k1, prior_list)
         _recursive_priors(kernel.k2, prior_list)
     elif hasattr(kernel, "kernels"):  # CompoundKernel
+        # It seems that the skopt kernels are not compatible with the
+        # CompoundKernel. This is therefore not officially supported.
         for k in kernel.kernels:
             _recursive_priors(k, prior_list)
     else:
         name = type(kernel).__name__
         if name in ["ConstantKernel", "WhiteKernel"]:
+            if name == "ConstantKernel" and kernel.constant_value_bounds == "fixed":
+                return
+            if name == "WhiteKernel" and kernel.noise_level_bounds == "fixed":
+                return
             # We use a half-normal prior distribution on the signal variance and
             # noise. The input x is sampled in log-space, which is why the
             # change of variables is necessary.

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -1,0 +1,11 @@
+import numpy as np
+from numpy.testing import assert_almost_equal
+from scipy.integrate import quad
+
+from bask.priors import make_roundflat
+
+
+def test_make_roundflat():
+    prior = make_roundflat()
+    value = quad(lambda x: np.exp(prior(x)), 0.0, 10.0)[0]
+    assert_almost_equal(value, 1.0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,9 @@
 from numpy.testing import assert_almost_equal
-from sklearn.gaussian_process.kernels import CompoundKernel
 from skopt.learning.gaussian_process.kernels import (
-    ExpSineSquared,
     Matern,
     ConstantKernel,
     WhiteKernel,
     Exponentiation,
-    DotProduct,
-    Product,
-    RationalQuadratic,
-    RBF,
 )
 from bask.utils import guess_priors, construct_default_kernel
 
@@ -24,19 +18,16 @@ def test_guess_priors():
     correctly."""
     kernel = Exponentiation(
         ConstantKernel(constant_value_bounds="fixed") * Matern()
-        + WhiteKernel()
-        + CompoundKernel([RBF(), Matern()]),
+        + WhiteKernel(),
         2.0,
     )
 
     priors = guess_priors(kernel)
 
-    assert len(priors) == 4
+    assert len(priors) == 2
     expected = [
-        -1.737085713764618,
-        -4.107091211892862,
-        -1.737085713764618,
-        -1.737085713764618,
+        -0.02116327824572739,
+        -2.112906921232193,
     ]
     for p, v in zip(priors, expected):
-        assert_almost_equal(p(0.0), v)
+        assert_almost_equal(p(-0.9), v)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,10 @@
 from numpy.testing import assert_almost_equal
 from skopt.learning.gaussian_process.kernels import (
-    Matern,
     ConstantKernel,
-    WhiteKernel,
     Exponentiation,
+    Matern,
+    RBF,
+    WhiteKernel,
 )
 from bask.utils import guess_priors, construct_default_kernel
 
@@ -18,16 +19,19 @@ def test_guess_priors():
     correctly."""
     kernel = Exponentiation(
         ConstantKernel(constant_value_bounds="fixed") * Matern()
-        + WhiteKernel(),
+        + WhiteKernel()
+        + RBF(length_scale=(1.0, 1.0)),
         2.0,
     )
 
     priors = guess_priors(kernel)
 
-    assert len(priors) == 2
+    assert len(priors) == 4
     expected = [
         -0.02116327824572739,
         -2.112906921232193,
+        -0.02116327824572739,
+        -0.02116327824572739,
     ]
     for p, v in zip(priors, expected):
         assert_almost_equal(p(-0.9), v)


### PR DESCRIPTION
This pull request replaces the existing inverse gamma distribution priors by round-flat distribution priors. These have the following advantages:

1. Flat in between the bounds, similar to a uniform distribution, which allows the GP marginal likelihood to dictate the shape of the posterior distribution.
2. Likelihood decays sharply, but smoothly when approaching the bounds. Preventing the posterior distribution from diverging.
3. Easier to set by the user.

In addition, this pull request fixes a bug in the `guess_priors` function. Causing it to not correctly specify priors for lengthscales.