### PR TITLE
Tighten lengthscale bounds for default kernel

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.7.1 (2020-07-28)
+------------------
+* Restrict length scale bounds of the default kernel to a tighter interval.
+  This should help start the MCMC walkers in a region with higher likelihood.
+
 0.7.0 (2020-07-26)
 ------------------
 * Replace the default inverse gamma distribution prior for the lengthscales by the round-flat distribution.

--- a/bask/utils.py
+++ b/bask/utils.py
@@ -136,7 +136,7 @@ def construct_default_kernel(dimensions):
     kernel = ConstantKernel(
         constant_value=1.0, constant_value_bounds=(0.1, 2.0)
     ) * Matern(
-        length_scale=[0.3] * n_parameters, length_scale_bounds=(0.05, 1.0), nu=2.5
+        length_scale=[0.3] * n_parameters, length_scale_bounds=(0.2, 0.5), nu=2.5
     )
     return kernel
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -98,4 +98,4 @@ def test_expected_optimality_gap(random_state):
         n_random_starts=10,
         tol=0.1,
     )
-    np.testing.assert_almost_equal(gap, 0.307, decimal=2)
+    np.testing.assert_almost_equal(gap, 0.257190451704128, decimal=2)


### PR DESCRIPTION
We still use a maximum marginal likelihood estimator for the hyperparameters to initialize the MCMC walkers. The lengthscale bounds ensure that we do not diverge at this stage.
The bounds are a bit too wide when compared to our prior distribution, which can cause the MCMC walkers to start in a region with low likelihood. This pull request fixes that problem.