### PR TITLE
Fix guess_prior not correctly adding a prior for the white noise kernel

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+Unreleased
+----------
+* Fix ``guess_priors`` not correctly adding the prior for the ``WhiteKernel``.
+  It is now called directly in ``BayesGPR.sample``.
+
 0.7.1 (2020-07-28)
 ------------------
 * Restrict length scale bounds of the default kernel to a tighter interval.

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -61,8 +61,9 @@ def test_no_error_on_unknown_kwargs():
 
 
 def test_error_on_invalid_priors():
+    opt = Optimizer(dimensions=[(-2.0, 2.0)], gp_priors=[], n_initial_points=0)
     with pytest.raises(ValueError):
-        Optimizer(dimensions=[(-2.0, 2.0)], gp_priors=[])
+        opt.tell([(0.0,)], 0.0)
 
 
 def test_probability_of_improvement(random_state):


### PR DESCRIPTION
`guess_prior` was already called in the `Optimizer` during initialization. The `WhiteKernel` in scikit-optimize is only added during fit.
This pull request moves the call to `guess_prior` into the `BayesGPR.sample` method where the kernel has been fully initialized.

The existing tests have been updated.