### PR TITLE
Add option to normalize optimality gap

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.8.0-beta.2 (2020-08-08)
+-------------------------
+* Add option to normalize the optimality gap when computing
+  ``Optimizer.expected_optimality_gap`` or
+  ``Optimizer.probability_of_optimality`` (activated by default).
+
 0.8.0-beta.1 (2020-08-07)
 -------------------------
 * Add ``Optimizer.optimum_intervals`` which computes the highest density

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -75,17 +75,39 @@ def test_probability_of_improvement(random_state):
         [[-2.0], [-1.0], [0.0], [1.0], [2.0]], [2.0, 0.0, -2.0, 0.0, 2.0], gp_burnin=10
     )
     prob = opt.probability_of_optimality(
-        threshold=1.0, n_random_starts=20, random_state=random_state
+        threshold=1.0,
+        n_random_starts=20,
+        random_state=random_state,
+        normalized_scores=False,
     )
     np.testing.assert_almost_equal(prob, 0.995)
 
     prob = opt.probability_of_optimality(
-        threshold=[0.9, 0.5], n_random_starts=20, random_state=random_state
+        threshold=[0.9, 0.5],
+        n_random_starts=20,
+        random_state=random_state,
+        normalized_scores=False,
     )
     np.testing.assert_almost_equal(prob, [0.925, 0.765], decimal=1)
 
+    prob = opt.probability_of_optimality(
+        threshold=1.0,
+        n_random_starts=20,
+        random_state=random_state,
+        normalized_scores=True,
+    )
+    np.testing.assert_almost_equal(prob, 0.99)
 
-def test_expected_optimality_gap(random_state):
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (dict(normalized_scores=False, use_mean_gp=True), 0.257),
+        (dict(normalized_scores=True, use_mean_gp=True), 0.23),
+        (dict(normalized_scores=True, use_mean_gp=False), 0.21),
+    ],
+)
+def test_expected_optimality_gap(random_state, input, expected):
     opt = Optimizer(
         dimensions=[(-2.0, 2.0)], n_initial_points=0, random_state=random_state
     )
@@ -99,8 +121,10 @@ def test_expected_optimality_gap(random_state):
         n_gp_samples=100,
         n_random_starts=10,
         tol=0.1,
+        use_mean_gp=input["use_mean_gp"],
+        normalized_scores=input["normalized_scores"],
     )
-    np.testing.assert_almost_equal(gap, 0.257190451704128, decimal=2)
+    np.testing.assert_almost_equal(gap, expected, decimal=2)
 
 
 def test_optimum_intervals():


### PR DESCRIPTION
Motivation
-----------
In `Optimizer.expected_optimality_gap` and `Optimizer.probability_of_optimality` we sample function realizations and use these to compute the maximal improvement we can get compared to our current optimum. If this is done across the hyperposterior on the kernel parameters, it can skew the result, if the signal variance differs for each Gaussian process.

Pull request
------------
This pull request implements a simple normalization by computing the standard deviation for each function realization and dividing the differences by the these standard deviations.
Slightly more accurate would be to use the exact signal variance which was used to generate the function realization, but it’s not returned by `BayesGPR.sample_y` yet.