### PR TITLE
Fix the calculation of max-value entropy search

### DIFF
--- a/bask/acquisition.py
+++ b/bask/acquisition.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 import scipy.stats as st
 from scipy.linalg import cho_solve, cholesky
-from scipy.optimize import bisect
+from scipy.optimize import brentq
 from sklearn.utils import check_random_state
 
 from bask.utils import get_progress_bar, validate_zeroone
@@ -229,34 +229,31 @@ class MaxValueSearch(UncertaintyAcquisition):
 
     def __call__(self, mu, std, *args, n_min_samples=1000, **kwargs):
         def probf(x):
-            return np.exp(np.sum(st.norm.logcdf(-(x - mu) / std), axis=0))
+            return np.exp(np.sum(st.norm.logcdf((x - mean) / std), axis=0))
 
-        idx = np.argmin(mu)
-        right = mu[idx].flatten()
-        left = right
-        i = 0
-        while probf(left) < 0.75:
-            left = 2.0 ** i * np.min(mu - 5.0 * std) + (1.0 - 2.0 ** i) * right
-            i += 1
+        # Negative sign, since the original algorithm is defined in terms of the maximum
+        mean = -mu
+        left = np.min(mean - 3 * std)
+        right = np.max(mean + 5 * std)
         # Binary search for 3 percentiles
-        q1, med, q2 = map(
-            lambda val: bisect(
-                lambda x: probf(x) - val, left, right, maxiter=10000, xtol=0.01
-            ),
-            [0.25, 0.5, 0.75],
-        )
+        q1, med, q2 = [
+            brentq(lambda x: probf(x) - val, left, right,) for val in [0.25, 0.5, 0.75]
+        ]
         beta = (q1 - q2) / (np.log(np.log(4.0 / 3.0)) - np.log(np.log(4.0)))
         alpha = med + beta * np.log(np.log(2.0))
-        mins = (
+        max_values = (
             -np.log(-np.log(np.random.rand(n_min_samples).astype(np.float32))) * beta
             + alpha
         )
 
-        gamma = (mu[:, None] - mins[None, :]) / std[:, None]
-        return np.sum(
-            gamma * st.norm().pdf(gamma) / (2.0 * st.norm().cdf(gamma))
-            - st.norm().logcdf(gamma),
-            axis=1,
+        gamma = (max_values[None, :] - mean[:, None]) / std[:, None]
+        return (
+            np.sum(
+                gamma * st.norm().pdf(gamma) / (2.0 * st.norm().cdf(gamma))
+                - st.norm().logcdf(gamma),
+                axis=1,
+            )
+            / n_min_samples
         )
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The bracketing interval was constructed incorrectly. This caused the acquisition function to output incorrect values or even raise a ValueError. Now we construct the bracketing interval more robustly and switch to the more robust [`brentq`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.brentq.html) method.
We also switch from calculating the distribution of the minimum values to calculating the distribution of the *maximum* values. We incorrectly used the wrong Gumbel distribution to fit the minimum distribution, which is now fixed.

Reference:
[Max-value Entropy Search for Efficient Bayesian Optimization](https://arxiv.org/abs/1703.01968)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test for max-value entropy search and ran it.

## Does this close/impact existing issues?
<!--- Please link to all relevant issues. -->
Fixes #30 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
