### PR TITLE
Fix handling of normalize_y

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.10.3 (2021-02-07)
+-------------------
+* Fix a bug where the output ``y`` was not correctly normalized when passed to
+  ``BayesGPR.sample(...)``.
+* Fix not adjusting ``noise_vector`` when ``normalize_y=True``.
+
 0.10.2 (2020-09-28)
 -------------------
 * Fix divide by zero encountered in log when evaluating acquisition functions

--- a/bask/bayesgpr.py
+++ b/bask/bayesgpr.py
@@ -590,6 +590,11 @@ class BayesGPR(GaussianProcessRegressor):
 
         """
         self.kernel = self._kernel
+        # In sklearn >= 23 the normalization includes scaling the output by the
+        # standard deviation. We need to scale the noise_vector accordingly here:
+        if int(sklearn.__version__[2:4]) >= 23 and self.normalize_y:
+            y_std = np.std(y, axis=0)
+            noise_vector = np.array(noise_vector) / np.power(y_std, 2)
         self._apply_noise_vector(len(y), noise_vector)
         super().fit(X, y)
 

--- a/bask/bayesgpr.py
+++ b/bask/bayesgpr.py
@@ -592,7 +592,11 @@ class BayesGPR(GaussianProcessRegressor):
         self.kernel = self._kernel
         # In sklearn >= 23 the normalization includes scaling the output by the
         # standard deviation. We need to scale the noise_vector accordingly here:
-        if int(sklearn.__version__[2:4]) >= 23 and self.normalize_y:
+        if (
+            int(sklearn.__version__[2:4]) >= 23
+            and self.normalize_y
+            and noise_vector is not None
+        ):
             y_std = np.std(y, axis=0)
             noise_vector = np.array(noise_vector) / np.power(y_std, 2)
         self._apply_noise_vector(len(y), noise_vector)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In scikit-learn 0.23 and higher, normalize_y also divides the output y by the standard deviation.
This was not handled correctly in `BayesGPR.sample`. In addition, the noise_vector the user can pass
to `BayesGPR.fit` and `BayesGPR.sample`, also needs to be adjusted

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The change was manually tested.

## Does this close/impact existing issues?
<!--- Please link to all relevant issues. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
