### PR TITLE
Correctly warp X in PVRS to include the Thompson points

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.10.4 (2021-02-11)
+-------------------
+* Fix a bug in the predictive variance reduction search (PVRS) acquisition
+  function, where the inputs were not warped correctly.
+
 0.10.3 (2021-02-07)
 -------------------
 * Fix a bug where the output ``y`` was not correctly normalized when passed to

--- a/bask/acquisition.py
+++ b/bask/acquisition.py
@@ -308,10 +308,12 @@ class PVRS(FullGPAcquisition):
         thompson_sample = gp.sample_y(
             X, sample_mean=True, n_samples=n_thompson, random_state=random_state
         )
-        thompson_points = np.array(X)[np.argmin(thompson_sample, axis=0)]
-        covs = np.empty(n)
+        # gp.sample_y internally warps the inputs, but now we need to first warp X
+        # such that the thompson_points are considered in the warped space:
         if gp.warp_inputs:
             X = gp.warp(X)
+        thompson_points = np.array(X)[np.argmin(thompson_sample, axis=0)]
+        covs = np.empty(n)
         for i in range(n):
             X_train_aug = np.concatenate([gp.X_train_, [X[i]]])
             K = gp.kernel_(X_train_aug)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the order in which X is warped inside the predictive variance reduction search acquisition function (PVRS).
Now it *first* transforms X and then selects the subset of Thompson points.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The PVRS acquisition function behaved strangely and appeared to not focus on promising regions. It turns out that the Thompson points it sampled were not warped and thus the acquisition function tried to reduce the predictive variance for a different set of points.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The behavior of PVRS was evaluated on a test tune.

## Does this close/impact existing issues?
<!--- Please link to all relevant issues. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
