### PR TITLE
Fix n_samples becoming numpy.float64

### DIFF
--- a/bask/bayesgpr.py
+++ b/bask/bayesgpr.py
@@ -484,7 +484,7 @@ class BayesGPR(GaussianProcessRegressor):
 
         n_dim = len(self.theta)
         n_walkers = n_threads * n_walkers_per_thread
-        n_samples = np.ceil(n_desired_samples / n_walkers) + n_burnin
+        n_samples = int(np.ceil(n_desired_samples / n_walkers) + n_burnin)
         pos = None
         if position is not None:
             pos = position


### PR DESCRIPTION
Fixes an issue wherein `bask` would internally set `n_samples` to a `numpy.float64` instead of an `int`, causing a crash.

## Description

Added `int` around the numpy arithmetic. It's literally one line of code.

## Motivation and Context

For an example of this error appearing, see [here](https://github.com/evhub/bbopt/runs/3054092560?check_suite_focus=true).

## How Has This Been Tested?

I verified locally that this change makes my error go away.

## Does this close/impact existing issues?

No.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
