### PR TITLE
chore: migrate formatting and linting to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,6 @@
 repos:
-  - repo: local
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.2
     hooks:
-      - id: black
-        name: black
-        entry: black
-        language: system
-        types: [python]
-        require_serial: true
-      - id: isort
-        name: isort
-        entry: isort
-        language: system
-        types: [python]
-      - id: flake8
-        name: flake8
-        entry: flake8
-        language: system
-        types: [python]
-        require_serial: true
+      - id: ruff-format
+      - id: ruff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@
 - Build packages with `make dist`; generated artifacts appear in `dist/`.
 
 ## Style & Formatting
-- Use `black` and `isort` before committing; the shared config keeps formatting deterministic.
-- Follow `flake8` rules (80-character lines, Google import order, select=B,C,E,F,W,T4,B9). Resolve warnings instead of adding ignores.
+- Use `ruff format` before committing; the shared config keeps formatting deterministic.
+- Follow the Ruff lint configuration (80-character lines, Google import order, select=B,C90,E,F,W) and resolve warnings instead of adding ignores.
 - Prefer `snake_case` for modules and functions, `PascalCase` for classes, and `UPPER_SNAKE_CASE` for constants. Keep docstrings concise and NumPy-style when detailing parameters.
 
 ## Testing Expectations

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -77,12 +77,11 @@ Ready to contribute? Here's how to set up `bask` for local development.
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass the linters and the
-   tests, including running the Nox matrix locally if you can::
+5. When you're done making changes, check that your changes pass the formatter,
+   linters, and tests, including running the Nox matrix locally if you can::
 
-       $ uv run black bask tests
-       $ uv run isort bask tests
-       $ uv run flake8
+       $ uv run ruff format bask tests
+       $ uv run ruff check bask tests
        $ uv run pytest bask tests
        $ uv run nox -s tests
 

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,9 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
 
-lint: ## check style with flake8
-	flake8 bask tests
+lint: ## check style with Ruff
+	uv run ruff format --check bask tests
+	uv run ruff check bask tests
 
 test: ## run tests quickly with the default Python
 	pytest

--- a/bask/acquisition.py
+++ b/bask/acquisition.py
@@ -93,7 +93,9 @@ def evaluate_acquisitions(
     n_acqs = len(acquisition_functions)
     acq_output = np.zeros((n_acqs, n_cand_points))
     random_state = check_random_state(random_state)
-    trace_sample_i = random_state.choice(len(gpr.chain_), replace=False, size=n_samples)
+    trace_sample_i = random_state.choice(
+        len(gpr.chain_), replace=False, size=n_samples
+    )
     theta_backup = np.copy(gpr.theta)
     if gpr.warp_inputs:
         alphas_backup = np.copy(gpr.warp_alphas_)
@@ -129,7 +131,9 @@ def evaluate_acquisitions(
                 elif isinstance(acq, SampleAcquisition):
                     if not sample_generated:
                         sample_generated = True
-                        sample = gpr.sample_y(X, random_state=random_state).flatten()
+                        sample = gpr.sample_y(
+                            X, random_state=random_state
+                        ).flatten()
                     tmp_out = acq(sample, **kwargs)
                 else:
                     continue
@@ -247,7 +251,8 @@ class MaxValueSearch(UncertaintyAcquisition):
         beta = (q1 - q2) / (np.log(np.log(4.0 / 3.0)) - np.log(np.log(4.0)))
         alpha = med + beta * np.log(np.log(2.0))
         max_values = (
-            -np.log(-np.log(np.random.rand(n_min_samples).astype(np.float32))) * beta
+            -np.log(-np.log(np.random.rand(n_min_samples).astype(np.float32)))
+            * beta
             + alpha
         )
 
@@ -308,7 +313,9 @@ class PVRS(FullGPAcquisition):
     Bayesian optimization at neural information processing systems (NIPSW). 2017.
     """
 
-    def __call__(self, X, gp, *args, n_thompson=10, random_state=None, **kwargs):
+    def __call__(
+        self, X, gp, *args, n_thompson=10, random_state=None, **kwargs
+    ):
         n = len(X)
         thompson_sample = gp.sample_y(
             X, sample_mean=True, n_samples=n_thompson, random_state=random_state

--- a/bask/bayesgpr.py
+++ b/bask/bayesgpr.py
@@ -241,7 +241,9 @@ class BayesGPR(GaussianProcessRegressor):
             self._X_train_warped_ = np.copy(self._X_train_orig_)
             if hasattr(self, "warpers_"):
                 for col, warper in enumerate(self.warpers_):
-                    self._X_train_warped_[:, col] = warper(self._X_train_orig_[:, col])
+                    self._X_train_warped_[:, col] = warper(
+                        self._X_train_orig_[:, col]
+                    )
             # If no warpers exist yet, we begin with an unwarped input space
 
     def warp(self, X):
@@ -288,7 +290,9 @@ class BayesGPR(GaussianProcessRegressor):
             if hasattr(self, "warpers_") and hasattr(self, "_X_train_orig_"):
                 self._X_train_warped_ = np.empty_like(self._X_train_orig_)
                 for col, warper in enumerate(self.warpers_):
-                    self._X_train_warped_[:, col] = warper(self._X_train_orig_[:, col])
+                    self._X_train_warped_[:, col] = warper(
+                        self._X_train_orig_[:, col]
+                    )
 
     def create_warpers(self, alphas, betas):
         """Create Beta CDFs and inverse CDFs for input (un)warping.
@@ -321,8 +325,12 @@ class BayesGPR(GaussianProcessRegressor):
         current_theta = self.theta
         try:
             # Now we set the noise to 0, but do NOT recalculate the alphas!:
-            white_present, white_param = _param_for_white_kernel_in_Sum(self.kernel_)
-            self.kernel_.set_params(**{white_param: WhiteKernel(noise_level=0.0)})
+            white_present, white_param = _param_for_white_kernel_in_Sum(
+                self.kernel_
+            )
+            self.kernel_.set_params(
+                **{white_param: WhiteKernel(noise_level=0.0)}
+            )
             yield self
         finally:
             self.kernel_.theta = current_theta
@@ -333,7 +341,9 @@ class BayesGPR(GaussianProcessRegressor):
         if noise_vector is not None:
             if not np.iterable(self.alpha):
                 alpha = np.ones(n_instances) * self.alpha
-            elif not np.iterable(self._alpha):  # we already changed self.alpha before
+            elif not np.iterable(
+                self._alpha
+            ):  # we already changed self.alpha before
                 alpha = np.ones(n_instances) * self._alpha
             alpha[: len(noise_vector)] += noise_vector
             self.alpha = alpha
@@ -468,7 +478,9 @@ class BayesGPR(GaussianProcessRegressor):
             y = (y - self.y_train_mean_) / self.y_train_std_
 
             if noise_vector is not None:
-                noise_vector = np.array(noise_vector) / np.power(self.y_train_std_, 2)
+                noise_vector = np.array(noise_vector) / np.power(
+                    self.y_train_std_, 2
+                )
 
             self.X_train_ = np.copy(X) if self.copy_X_train else X
             self.y_train_ = np.copy(y) if self.copy_X_train else y
@@ -492,7 +504,8 @@ class BayesGPR(GaussianProcessRegressor):
             if self.warp_inputs:
                 theta = np.concatenate([theta, np.zeros(added_dims)])
             pos = [
-                theta + 1e-2 * self.random_state.randn(n_dim) for _ in range(n_walkers)
+                theta + 1e-2 * self.random_state.randn(n_dim)
+                for _ in range(n_walkers)
             ]
         self._sampler = mc.EnsembleSampler(
             nwalkers=n_walkers,
@@ -506,11 +519,15 @@ class BayesGPR(GaussianProcessRegressor):
             self.random_state.randint(0, np.iinfo(np.int32).max)
         )
         self._sampler.random_state = rng.get_state()
-        pos, prob, state = self._sampler.run_mcmc(pos, n_samples, progress=progress)
+        pos, prob, state = self._sampler.run_mcmc(
+            pos, n_samples, progress=progress
+        )
         # if backup_file is not None:
         #     with open(backup_file, "wb") as f:
         #         np.save(f, pos)
-        chain = self._sampler.get_chain(flat=True, discard=n_burnin, thin=n_thin)
+        chain = self._sampler.get_chain(
+            flat=True, discard=n_burnin, thin=n_thin
+        )
         if add and self.chain_ is not None:
             self.chain_ = np.concatenate([self.chain_, chain])
         else:
@@ -617,7 +634,9 @@ class BayesGPR(GaussianProcessRegressor):
             X, return_std, return_cov, return_mean_grad, return_std_grad
         )
 
-    def sample_y(self, X, sample_mean=False, noise=False, n_samples=1, random_state=0):
+    def sample_y(
+        self, X, sample_mean=False, noise=False, n_samples=1, random_state=0
+    ):
         """Sample function realizations of the Gaussian process.
 
         Parameters
@@ -653,7 +672,9 @@ class BayesGPR(GaussianProcessRegressor):
             else:
                 cm = self.noise_set_to_zero()
             with cm:
-                samples = super().sample_y(X, n_samples=n_samples, random_state=rng)
+                samples = super().sample_y(
+                    X, n_samples=n_samples, random_state=rng
+                )
             return samples
         ind = rng.choice(len(self.chain_), size=n_samples, replace=True)
         if self.warp_inputs:
@@ -670,7 +691,10 @@ class BayesGPR(GaussianProcessRegressor):
                 validate_zeroone(X)
                 theta = self.chain_[j][:n_dims]
                 warp_params = self.chain_[j][n_dims:]
-                alphas, betas = warp_params[: X.shape[1]], warp_params[X.shape[1] :]
+                alphas, betas = (
+                    warp_params[: X.shape[1]],
+                    warp_params[X.shape[1] :],
+                )
                 self.create_warpers(alphas, betas)
                 self.rewarp()
             else:

--- a/bask/optimizer.py
+++ b/bask/optimizer.py
@@ -220,7 +220,9 @@ class Optimizer:
                 )[0]
             return self.space.rvs()[0]
         if not self.gp.kernel_:
-            raise RuntimeError("Initialization is finished, but no model has been fit.")
+            raise RuntimeError(
+                "Initialization is finished, but no model has been fit."
+            )
         return self._next_x
 
     def tell(
@@ -355,7 +357,9 @@ class Optimizer:
                 X = self.gp.unwarp(X_warped)
             else:
                 X = self.space.transform(
-                    self.space.rvs(n_samples=self.n_points, random_state=self.rng)
+                    self.space.rvs(
+                        n_samples=self.n_points, random_state=self.rng
+                    )
                 )
             acq_values = evaluate_acquisitions(
                 X=X,
@@ -371,10 +375,18 @@ class Optimizer:
                 X[np.argmax(acq_values)].reshape((1, -1))
             )[0]
 
-        return create_result(self.Xi, self.yi, self.space, self.rng, models=[self.gp])
+        return create_result(
+            self.Xi, self.yi, self.space, self.rng, models=[self.gp]
+        )
 
     def run(
-        self, func, n_iter=1, replace=False, n_samples=5, gp_samples=100, gp_burnin=10
+        self,
+        func,
+        n_iter=1,
+        replace=False,
+        n_samples=5,
+        gp_samples=100,
+        gp_burnin=10,
     ):
         """Execute the ask/tell-loop on a given objective function.
 
@@ -428,7 +440,9 @@ class Optimizer:
             )
             replace = False
 
-        return create_result(self.Xi, self.yi, self.space, self.rng, models=[self.gp])
+        return create_result(
+            self.Xi, self.yi, self.space, self.rng, models=[self.gp]
+        )
 
     def probability_of_optimality(
         self,
@@ -473,10 +487,14 @@ class Optimizer:
         probabilities : float or list-of-floats
             Probabilities of the current optimum to be optimal wrt the given thresholds.
         """
-        result = create_result(self.Xi, self.yi, self.space, self.rng, models=[self.gp])
+        result = create_result(
+            self.Xi, self.yi, self.space, self.rng, models=[self.gp]
+        )
         X_orig = [
             expected_minimum(
-                result, random_state=random_state, n_random_starts=n_random_starts
+                result,
+                random_state=random_state,
+                n_random_starts=n_random_starts,
             )[0]
         ]
 
@@ -581,7 +599,9 @@ class Optimizer:
             except ValueError:
                 pass
         else:
-            raise ValueError("Determining the upper threshold was not possible.")
+            raise ValueError(
+                "Determining the upper threshold was not possible."
+            )
 
         thresholds = list(np.linspace(0, upper_threshold, num=n_probabilities))
         probabilities = self.probability_of_optimality(
@@ -653,12 +673,17 @@ class Optimizer:
         X = self.space.rvs(n_samples=space_samples, random_state=random_state)
         X = self.space.transform(X)
         optimum_samples = self.gp.sample_y(
-            X, sample_mean=only_mean, n_samples=opt_samples, random_state=random_state
+            X,
+            sample_mean=only_mean,
+            n_samples=opt_samples,
+            random_state=random_state,
         )
         X_opt = X[np.argmin(optimum_samples, axis=0)]
 
         intervals = []
         for i, col in enumerate(X_opt.T):
             raw_interval = hdi(col, hdi_prob=hdi_prob, multimodal=multimodal)
-            intervals.append(self.space.dimensions[i].inverse_transform(raw_interval))
+            intervals.append(
+                self.space.dimensions[i].inverse_transform(raw_interval)
+            )
         return intervals

--- a/bask/priors.py
+++ b/bask/priors.py
@@ -46,7 +46,9 @@ def make_roundflat(
         )
 
     value = quad(
-        lambda x: np.exp(roundflat(x)), integration_bounds[0], integration_bounds[1]
+        lambda x: np.exp(roundflat(x)),
+        integration_bounds[0],
+        integration_bounds[1],
     )[0]
 
     def prior(x):

--- a/bask/searchcv.py
+++ b/bask/searchcv.py
@@ -139,21 +139,21 @@ class BayesSearchCV(BayesSearchCVSK):
     >>> from sklearn.model_selection import train_test_split
     >>>
     >>> X, y = load_iris(True)
-    >>> X_train, X_test, y_train, y_test = train_test_split(X, y,
-    ...                                                     train_size=0.75,
-    ...                                                     random_state=0)
+    >>> X_train, X_test, y_train, y_test = train_test_split(
+    ...     X, y, train_size=0.75, random_state=0
+    ... )
     >>>
     >>> # log-uniform: understand as search over p = exp(x) by varying x
     >>> opt = BayesSearchCV(
     ...     SVC(),
     ...     {
-    ...         'C': Real(1e-6, 1e+6, prior='log-uniform'),
-    ...         'gamma': Real(1e-6, 1e+1, prior='log-uniform'),
-    ...         'degree': Integer(1,8),
-    ...         'kernel': Categorical(['linear', 'poly', 'rbf']),
+    ...         "C": Real(1e-6, 1e6, prior="log-uniform"),
+    ...         "gamma": Real(1e-6, 1e1, prior="log-uniform"),
+    ...         "degree": Integer(1, 8),
+    ...         "kernel": Categorical(["linear", "poly", "rbf"]),
     ...     },
     ...     n_iter=32,
-    ...     random_state=0
+    ...     random_state=0,
     ... )
     >>>
     >>> # executes bayesian optimization
@@ -311,12 +311,19 @@ class BayesSearchCV(BayesSearchCVSK):
         for i in range(len(optimizer.space.dimensions)):
             if optimizer.space.dimensions[i].name is not None:
                 continue
-            optimizer.space.dimensions[i].name = list(sorted(params_space.keys()))[i]
+            optimizer.space.dimensions[i].name = list(
+                sorted(params_space.keys())
+            )[i]
 
         return optimizer
 
     def _step(
-        self, search_space, optimizer, score_name, evaluate_candidates, n_points=1
+        self,
+        search_space,
+        optimizer,
+        score_name,
+        evaluate_candidates,
+        n_points=1,
     ):
         """Generate n_jobs parameters and evaluate them in parallel."""
 

--- a/bask/utils.py
+++ b/bask/utils.py
@@ -79,7 +79,10 @@ def _recursive_priors(kernel, prior_list):
     else:
         name = type(kernel).__name__
         if name in ["ConstantKernel", "WhiteKernel"]:
-            if name == "ConstantKernel" and kernel.constant_value_bounds == "fixed":
+            if (
+                name == "ConstantKernel"
+                and kernel.constant_value_bounds == "fixed"
+            ):
                 return
             if name == "WhiteKernel" and kernel.noise_level_bounds == "fixed":
                 return
@@ -101,7 +104,9 @@ def _recursive_priors(kernel, prior_list):
             # For common optimization problems, we expect the lengthscales to
             # lie in the range [0.1, 0.6]. The round-flat prior allows values
             # outside the range, if supported by enough datapoints.
-            if isinstance(kernel.length_scale, (collections.abc.Sequence, np.ndarray)):
+            if isinstance(
+                kernel.length_scale, (collections.abc.Sequence, np.ndarray)
+            ):
                 n_priors = len(kernel.length_scale)
             else:
                 n_priors = 1
@@ -139,7 +144,9 @@ def construct_default_kernel(dimensions):
     kernel = ConstantKernel(
         constant_value=1.0, constant_value_bounds=(0.1, 2.0)
     ) * Matern(
-        length_scale=[0.3] * n_parameters, length_scale_bounds=(0.2, 0.5), nu=2.5
+        length_scale=[0.3] * n_parameters,
+        length_scale_bounds=(0.2, 0.5),
+        nu=2.5,
     )
     return kernel
 

--- a/examples/Fit-GP.ipynb
+++ b/examples/Fit-GP.ipynb
@@ -18,9 +18,9 @@
     "%matplotlib inline\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "import bask\n",
     "from bask import BayesGPR\n",
-    "plt.style.use('bmh')\n",
+    "\n",
+    "plt.style.use(\"bmh\")\n",
     "colors = plt.cm.get_cmap(\"Set1\").colors"
    ]
   },
@@ -40,8 +40,8 @@
    "source": [
     "rand = np.random.RandomState(123)\n",
     "n_points = 100\n",
-    "noise = 1.\n",
-    "frequency = 3.\n",
+    "noise = 1.0\n",
+    "frequency = 3.0\n",
     "X = rand.uniform(-1, 1, size=n_points)[:, None]\n",
     "y = np.sin(X * frequency).flatten() + rand.randn(n_points) * noise"
    ]
@@ -1133,7 +1133,8 @@
    "source": [
     "from skopt.learning.gaussian_process.kernels import Matern\n",
     "from scipy.stats import invgamma, halfnorm\n",
-    "kernel = 1.0 ** 2 + Matern(length_scale=1., length_scale_bounds=(0.1, 2.))"
+    "\n",
+    "kernel = 1.0**2 + Matern(length_scale=1.0, length_scale_bounds=(0.1, 2.0))"
    ]
   },
   {
@@ -1159,11 +1160,15 @@
    "source": [
     "priors = [\n",
     "    # Prior distribution for the signal variance:\n",
-    "    lambda x: halfnorm(scale=2.).logpdf(np.sqrt(np.exp(x))) + x / 2.0 - np.log(2.0),\n",
+    "    lambda x: halfnorm(scale=2.0).logpdf(np.sqrt(np.exp(x)))\n",
+    "    + x / 2.0\n",
+    "    - np.log(2.0),\n",
     "    # Prior distribution for the length scale:\n",
     "    lambda x: invgamma(a=9, scale=11).logpdf(np.exp(x)) + x,\n",
     "    # Prior distribution for the noise:\n",
-    "    lambda x: halfnorm(scale=2.).logpdf(np.sqrt(np.exp(x))) + x / 2.0 - np.log(2.0)\n",
+    "    lambda x: halfnorm(scale=2.0).logpdf(np.sqrt(np.exp(x)))\n",
+    "    + x / 2.0\n",
+    "    - np.log(2.0),\n",
     "]"
    ]
   },
@@ -2936,10 +2941,24 @@
     "    yy, yy_ste = gp.predict(xx, return_std=True)\n",
     "_, yy_std = gp.predict(xx, return_std=True)\n",
     "ax.plot(xx, yy, color=colors[6], zorder=3, label=\"GP mean process\")\n",
-    "ax.fill_between(xx.flatten(), yy-yy_ste*1.96, yy+yy_ste * 1.96, alpha=0.3, color=colors[6], zorder=1,\n",
-    "                label=\"2xSE\")\n",
-    "ax.fill_between(xx.flatten(), yy-yy_std*1.96, yy+yy_std * 1.96, alpha=0.2, color=colors[6], zorder=0,\n",
-    "                label=\"2xSD\")\n",
+    "ax.fill_between(\n",
+    "    xx.flatten(),\n",
+    "    yy - yy_ste * 1.96,\n",
+    "    yy + yy_ste * 1.96,\n",
+    "    alpha=0.3,\n",
+    "    color=colors[6],\n",
+    "    zorder=1,\n",
+    "    label=\"2xSE\",\n",
+    ")\n",
+    "ax.fill_between(\n",
+    "    xx.flatten(),\n",
+    "    yy - yy_std * 1.96,\n",
+    "    yy + yy_std * 1.96,\n",
+    "    alpha=0.2,\n",
+    "    color=colors[6],\n",
+    "    zorder=0,\n",
+    "    label=\"2xSD\",\n",
+    ")\n",
     "plt.legend(loc=2);"
    ]
   },
@@ -5636,7 +5655,9 @@
     "fig, ax = plt.subplots(figsize=(9, 5))\n",
     "ax.plot(X, y, \"o\", color=colors[1], zorder=2, label=\"Noisy data\", alpha=0.7)\n",
     "\n",
-    "ax.plot(xx, YY, color=colors[6], zorder=3, label=\"GP realizations\", linewidth=1.);"
+    "ax.plot(\n",
+    "    xx, YY, color=colors[6], zorder=3, label=\"GP realizations\", linewidth=1.0\n",
+    ");"
    ]
   },
   {
@@ -8439,7 +8460,9 @@
     "fig, ax = plt.subplots(figsize=(9, 5))\n",
     "ax.plot(X, y, \"o\", color=colors[1], zorder=2, label=\"Noisy data\", alpha=0.7)\n",
     "\n",
-    "ax.plot(xx, YY, color=colors[6], zorder=3, label=\"GP realizations\", linewidth=1.);"
+    "ax.plot(\n",
+    "    xx, YY, color=colors[6], zorder=3, label=\"GP realizations\", linewidth=1.0\n",
+    ");"
    ]
   },
   {

--- a/examples/Optimize-1D-function.ipynb
+++ b/examples/Optimize-1D-function.ipynb
@@ -18,9 +18,9 @@
     "%matplotlib inline\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "import bask\n",
     "from bask import Optimizer\n",
-    "plt.style.use('bmh')\n",
+    "\n",
+    "plt.style.use(\"bmh\")\n",
     "colors = plt.cm.get_cmap(\"Set1\").colors"
    ]
   },
@@ -1068,7 +1068,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parameters = [(0., 1.2)]"
+    "parameters = [(0.0, 1.2)]"
    ]
   },
   {
@@ -1087,7 +1087,8 @@
    "source": [
     "from skopt.learning.gaussian_process.kernels import Matern\n",
     "from scipy.stats import invgamma, halfnorm\n",
-    "kernel = 1.0 ** 2 + Matern(length_scale=1., length_scale_bounds=(0.1, 2.))"
+    "\n",
+    "kernel = 1.0**2 + Matern(length_scale=1.0, length_scale_bounds=(0.1, 2.0))"
    ]
   },
   {
@@ -1111,11 +1112,15 @@
    "source": [
     "priors = [\n",
     "    # Prior distribution for the signal variance:\n",
-    "    lambda x: halfnorm(scale=2.).logpdf(np.sqrt(np.exp(x))) + x / 2.0 - np.log(2.0),\n",
+    "    lambda x: halfnorm(scale=2.0).logpdf(np.sqrt(np.exp(x)))\n",
+    "    + x / 2.0\n",
+    "    - np.log(2.0),\n",
     "    # Prior distribution for the length scale:\n",
     "    lambda x: invgamma(a=8.29, scale=2.46).logpdf(np.exp(x)) + x,\n",
     "    # Prior distribution for the noise:\n",
-    "    lambda x: halfnorm(scale=0.5).logpdf(np.sqrt(np.exp(x))) + x / 2.0 - np.log(2.0)\n",
+    "    lambda x: halfnorm(scale=0.5).logpdf(np.sqrt(np.exp(x)))\n",
+    "    + x / 2.0\n",
+    "    - np.log(2.0),\n",
     "]"
    ]
   },
@@ -1142,7 +1147,7 @@
     "    gp_priors=priors,\n",
     "    acq_func=\"pvrs\",\n",
     "    acq_func_kwargs=dict(n_thompson=3),\n",
-    "    random_state=rand.randint(0, np.iinfo(np.int32).max)\n",
+    "    random_state=rand.randint(0, np.iinfo(np.int32).max),\n",
     ")"
    ]
   },
@@ -1205,7 +1210,11 @@
     "    opt.tell(x, y, n_samples=0, gp_samples=200, gp_burnin=5)\n",
     "    if i >= n_initial_points:\n",
     "        with opt.gp.noise_set_to_zero():\n",
-    "            predictions[i-n_initial_points] = np.array(opt.gp.predict(opt.space.transform(xx[:, None].tolist()), return_std=True)).T"
+    "            predictions[i - n_initial_points] = np.array(\n",
+    "                opt.gp.predict(\n",
+    "                    opt.space.transform(xx[:, None].tolist()), return_std=True\n",
+    "                )\n",
+    "            ).T"
    ]
   },
   {
@@ -6573,17 +6582,43 @@
     }
    ],
    "source": [
-    "fig, axes = plt.subplots(ncols=1, nrows=5, figsize=(9, 10), sharex=True, sharey=True)\n",
+    "fig, axes = plt.subplots(\n",
+    "    ncols=1, nrows=5, figsize=(9, 10), sharex=True, sharey=True\n",
+    ")\n",
     "it_to_plot = [0, 9, 12, 19, 29]\n",
     "for j, i in enumerate(it_to_plot):\n",
     "    mu, se = predictions[i, :, 0], predictions[i, :, 1]\n",
     "    axes[j].plot(xx, mu, color=colors[6], zorder=2, label=\"GP Mean\")\n",
-    "    axes[j].fill_between(xx, mu - 1.6 * se, mu + 1.6 * se, alpha=0.3, color=colors[6], zorder=0, label=\"84% Standard error\")\n",
-    "    axes[j].plot(opt.Xi[:i+1 + n_initial_points], opt.yi[:i+1 + n_initial_points], \"o\", color=colors[1], zorder=5, label=\"Observations\")\n",
-    "    axes[j].plot(xx, test_function(xx), \"--\", zorder=1, color=colors[1], label=\"True function\")\n",
-    "    axes[j].set_ylabel(f\"Iteration {i+n_initial_points+1}\")\n",
+    "    axes[j].fill_between(\n",
+    "        xx,\n",
+    "        mu - 1.6 * se,\n",
+    "        mu + 1.6 * se,\n",
+    "        alpha=0.3,\n",
+    "        color=colors[6],\n",
+    "        zorder=0,\n",
+    "        label=\"84% Standard error\",\n",
+    "    )\n",
+    "    axes[j].plot(\n",
+    "        opt.Xi[: i + 1 + n_initial_points],\n",
+    "        opt.yi[: i + 1 + n_initial_points],\n",
+    "        \"o\",\n",
+    "        color=colors[1],\n",
+    "        zorder=5,\n",
+    "        label=\"Observations\",\n",
+    "    )\n",
+    "    axes[j].plot(\n",
+    "        xx,\n",
+    "        test_function(xx),\n",
+    "        \"--\",\n",
+    "        zorder=1,\n",
+    "        color=colors[1],\n",
+    "        label=\"True function\",\n",
+    "    )\n",
+    "    axes[j].set_ylabel(f\"Iteration {i + n_initial_points + 1}\")\n",
     "plt.tight_layout()\n",
-    "plt.legend(loc=\"upper center\", bbox_to_anchor=(0.5, -0.1), fancybox=True, ncol=4);"
+    "plt.legend(\n",
+    "    loc=\"upper center\", bbox_to_anchor=(0.5, -0.1), fancybox=True, ncol=4\n",
+    ");"
    ]
   },
   {
@@ -6609,9 +6644,12 @@
    ],
    "source": [
     "from skopt.utils import expected_minimum, create_result\n",
+    "\n",
     "result_object = create_result(opt.Xi, opt.yi, space=opt.space, models=[opt.gp])\n",
     "opt_x, opt_y = expected_minimum(result_object)\n",
-    "print(f\"Best point found so far: x={np.around(opt_x[0], 4)}, y={np.around(opt_y, 4)}\")"
+    "print(\n",
+    "    f\"Best point found so far: x={np.around(opt_x[0], 4)}, y={np.around(opt_y, 4)}\"\n",
+    ")"
    ]
   }
  ],

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ import nox
 from nox import Session
 from nox_uv import session
 
-locations = "bask", "noxfile.py"
+locations = ("bask", "tests", "noxfile.py")
 nox.options.sessions = ("pre-commit", "tests")
 python_versions = ["3.10", "3.11", "3.12", "3.13"]
 nox.options.default_venv_backend = "uv"
@@ -39,7 +39,9 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
         text = hook.read_text()
         bindir = repr(session.bin)[1:-1]  # strip quotes
         if not (
-            Path("A") == Path("a") and bindir.lower() in text.lower() or bindir in text
+            Path("A") == Path("a")
+            and bindir.lower() in text.lower()
+            or bindir in text
         ):
             continue
 
@@ -69,10 +71,17 @@ def tests(session: Session) -> None:
 
 
 @session(python="3.13", uv_groups=["dev"])
-def black(session: Session) -> None:
-    """Run black code formatter."""
+def format(session: Session) -> None:
+    """Run Ruff formatter."""
     args = session.posargs or locations
-    session.run("black", *args)
+    session.run("ruff", "format", *args)
+
+
+@session(python="3.13", uv_groups=["dev"])
+def lint(session: Session) -> None:
+    """Run Ruff lint checks."""
+    args = session.posargs or locations
+    session.run("ruff", "check", *args)
 
 
 @session(name="pre-commit", python="3.13", uv_groups=["dev"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,13 +47,9 @@ Documentation = "https://bayes-skopt.readthedocs.io"
 
 [dependency-groups]
 dev = [
-    "black>=24.0.0",
     "coverage>=5.2.1",
     "doc8>=0.11.2",
-    "flake8>=3.8.3",
-    "flake8-bugbear>=20.1.4",
     "ipython>=7.17.0",
-    "isort>=5.3.0",
     "nbsphinx>=0.7.1",
     "nbsphinx-link>=1.3.0",
     "nox>=2024.4.15",
@@ -63,6 +59,7 @@ dev = [
     "pre-commit>=2.6.0",
     "pytest>=6.0.1",
     "pytest-runner>=5.2",
+    "ruff>=0.14.2",
     "Sphinx>=3.1.2",
     "twine>=3.2.0",
     "watchdog>=0.10.3",
@@ -75,6 +72,23 @@ build-backend = "setuptools.build_meta"
 
 [tool.uv]
 default-groups = ["dev"]
+
+[tool.ruff]
+line-length = 80
+target-version = "py310"
+
+[tool.ruff.format]
+docstring-code-format = true
+
+[tool.ruff.lint]
+select = ["B", "C90", "E", "F", "W"]
+ignore = ["E203", "E501", "F403", "F405"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["bask"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 18
 
 [tool.setuptools.packages.find]
 include = ["bask", "bask.*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,5 @@
 [bdist_wheel]
 universal = 1
 
-[flake8]
-ignore = E501, W503, F403, E203, F405
-exclude = docs
-max-line-length = 80
-max-complexity = 18
-import-order-style = google
-application-import-names = bask
-select = B,C,E,F,W,T4,B9
-
 [aliases]
 test = pytest

--- a/tests/test_bayesgpr.py
+++ b/tests/test_bayesgpr.py
@@ -12,7 +12,10 @@ def minimal_gp(request):
         constant_value=1**2, constant_value_bounds=(0.01**2, 1**2)
     ) * RBF(length_scale=1.0, length_scale_bounds=(0.5, 1.5))
     gp = BayesGPR(
-        random_state=1, normalize_y=False, kernel=kernel, warp_inputs=request.param
+        random_state=1,
+        normalize_y=False,
+        kernel=kernel,
+        warp_inputs=request.param,
     )
     return gp
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,9 +9,13 @@ def test_sb_sequence():
     assert x.shape == (5, 1)
 
     existing = [(0.5, 0.5)]
-    x = sb_sequence(n=5, d=2, existing_points=existing, random_state=random_state)
+    x = sb_sequence(
+        n=5, d=2, existing_points=existing, random_state=random_state
+    )
     assert x.shape == (5, 2)
 
     existing = [(0.5, 0.5)]
     with pytest.raises(ValueError):
-        sb_sequence(n=1, d=2, existing_points=existing, random_state=random_state)
+        sb_sequence(
+            n=1, d=2, existing_points=existing, random_state=random_state
+        )

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -28,7 +28,9 @@ def test_multiple_asks():
 @pytest.mark.parametrize("init_strategy", ("r2", "sb", "random"))
 def test_initial_points(init_strategy):
     opt = Optimizer(
-        dimensions=[(-2.0, 2.0)], n_initial_points=3, init_strategy=init_strategy
+        dimensions=[(-2.0, 2.0)],
+        n_initial_points=3,
+        init_strategy=init_strategy,
     )
     x = opt.ask()
     assert not isinstance(x[0], list)
@@ -95,7 +97,9 @@ def test_probability_of_improvement(random_state, input, expected):
         dimensions=[(-2.0, 2.0)], n_initial_points=0, random_state=random_state
     )
     opt.tell(
-        [[-2.0], [-1.0], [0.0], [1.0], [2.0]], [2.0, 0.0, -2.0, 0.0, 2.0], gp_burnin=10
+        [[-2.0], [-1.0], [0.0], [1.0], [2.0]],
+        [2.0, 0.0, -2.0, 0.0, 2.0],
+        gp_burnin=10,
     )
     prob = opt.probability_of_optimality(
         threshold=input["threshold"],
@@ -119,7 +123,9 @@ def test_expected_optimality_gap(random_state, input, expected):
         dimensions=[(-2.0, 2.0)], n_initial_points=0, random_state=random_state
     )
     opt.tell(
-        [[-2.0], [-1.0], [0.0], [1.0], [2.0]], [2.0, 0.0, -2.0, 0.0, 2.0], gp_burnin=10
+        [[-2.0], [-1.0], [0.0], [1.0], [2.0]],
+        [2.0, 0.0, -2.0, 0.0, 2.0],
+        gp_burnin=10,
     )
     gap = opt.expected_optimality_gap(
         random_state=random_state,

--- a/uv.lock
+++ b/uv.lock
@@ -107,13 +107,9 @@ docs = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "black" },
     { name = "coverage" },
     { name = "doc8" },
-    { name = "flake8" },
-    { name = "flake8-bugbear" },
     { name = "ipython" },
-    { name = "isort" },
     { name = "nbsphinx" },
     { name = "nbsphinx-link" },
     { name = "nox" },
@@ -123,6 +119,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-runner" },
+    { name = "ruff" },
     { name = "sphinx" },
     { name = "twine" },
     { name = "watchdog" },
@@ -148,13 +145,9 @@ provides-extras = ["docs", "data"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=24.0.0" },
     { name = "coverage", specifier = ">=5.2.1" },
     { name = "doc8", specifier = ">=0.11.2" },
-    { name = "flake8", specifier = ">=3.8.3" },
-    { name = "flake8-bugbear", specifier = ">=20.1.4" },
     { name = "ipython", specifier = ">=7.17.0" },
-    { name = "isort", specifier = ">=5.3.0" },
     { name = "nbsphinx", specifier = ">=0.7.1" },
     { name = "nbsphinx-link", specifier = ">=1.3.0" },
     { name = "nox", specifier = ">=2024.4.15" },
@@ -164,6 +157,7 @@ dev = [
     { name = "pre-commit", specifier = ">=2.6.0" },
     { name = "pytest", specifier = ">=6.0.1" },
     { name = "pytest-runner", specifier = ">=5.2" },
+    { name = "ruff", specifier = ">=0.14.2" },
     { name = "sphinx", specifier = ">=3.1.2" },
     { name = "twine", specifier = ">=3.2.0" },
     { name = "watchdog", specifier = ">=0.10.3" },
@@ -181,41 +175,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/77/e9/df2358efd7659577435e2177bfa69cba6c33216681af51a707193dec162a/beautifulsoup4-4.14.2.tar.gz", hash = "sha256:2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e", size = 625822, upload-time = "2025-09-29T10:05:42.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/fe/3aed5d0be4d404d12d36ab97e2f1791424d9ca39c2f754a6285d59a3b01d/beautifulsoup4-4.14.2-py3-none-any.whl", hash = "sha256:5ef6fa3a8cbece8488d66985560f97ed091e22bbc4e9c2338508a9d5de6d4515", size = 106392, upload-time = "2025-09-29T10:05:43.771Z" },
-]
-
-[[package]]
-name = "black"
-version = "25.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/43/20b5c90612d7bdb2bdbcceeb53d588acca3bb8f0e4c5d5c751a2c8fdd55a/black-25.9.0.tar.gz", hash = "sha256:0474bca9a0dd1b51791fcc507a4e02078a1c63f6d4e4ae5544b9848c7adfb619", size = 648393, upload-time = "2025-09-19T00:27:37.758Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/40/dbe31fc56b218a858c8fc6f5d8d3ba61c1fa7e989d43d4a4574b8b992840/black-25.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ce41ed2614b706fd55fd0b4a6909d06b5bab344ffbfadc6ef34ae50adba3d4f7", size = 1715605, upload-time = "2025-09-19T00:36:13.483Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b2/f46800621200eab6479b1f4c0e3ede5b4c06b768e79ee228bc80270bcc74/black-25.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2ab0ce111ef026790e9b13bd216fa7bc48edd934ffc4cbf78808b235793cbc92", size = 1571829, upload-time = "2025-09-19T00:32:42.13Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/64/5c7f66bd65af5c19b4ea86062bb585adc28d51d37babf70969e804dbd5c2/black-25.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f96b6726d690c96c60ba682955199f8c39abc1ae0c3a494a9c62c0184049a713", size = 1631888, upload-time = "2025-09-19T00:30:54.212Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/64/0b9e5bfcf67db25a6eef6d9be6726499a8a72ebab3888c2de135190853d3/black-25.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:d119957b37cc641596063cd7db2656c5be3752ac17877017b2ffcdb9dfc4d2b1", size = 1327056, upload-time = "2025-09-19T00:31:08.877Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/f4/7531d4a336d2d4ac6cc101662184c8e7d068b548d35d874415ed9f4116ef/black-25.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:456386fe87bad41b806d53c062e2974615825c7a52159cde7ccaeb0695fa28fa", size = 1698727, upload-time = "2025-09-19T00:31:14.264Z" },
-    { url = "https://files.pythonhosted.org/packages/28/f9/66f26bfbbf84b949cc77a41a43e138d83b109502cd9c52dfc94070ca51f2/black-25.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a16b14a44c1af60a210d8da28e108e13e75a284bf21a9afa6b4571f96ab8bb9d", size = 1555679, upload-time = "2025-09-19T00:31:29.265Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/59/61475115906052f415f518a648a9ac679d7afbc8da1c16f8fdf68a8cebed/black-25.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaf319612536d502fdd0e88ce52d8f1352b2c0a955cc2798f79eeca9d3af0608", size = 1617453, upload-time = "2025-09-19T00:30:42.24Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/5b/20fd5c884d14550c911e4fb1b0dae00d4abb60a4f3876b449c4d3a9141d5/black-25.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:c0372a93e16b3954208417bfe448e09b0de5cc721d521866cd9e0acac3c04a1f", size = 1333655, upload-time = "2025-09-19T00:30:56.715Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/8e/319cfe6c82f7e2d5bfb4d3353c6cc85b523d677ff59edc61fdb9ee275234/black-25.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1b9dc70c21ef8b43248f1d86aedd2aaf75ae110b958a7909ad8463c4aa0880b0", size = 1742012, upload-time = "2025-09-19T00:33:08.678Z" },
-    { url = "https://files.pythonhosted.org/packages/94/cc/f562fe5d0a40cd2a4e6ae3f685e4c36e365b1f7e494af99c26ff7f28117f/black-25.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8e46eecf65a095fa62e53245ae2795c90bdecabd53b50c448d0a8bcd0d2e74c4", size = 1581421, upload-time = "2025-09-19T00:35:25.937Z" },
-    { url = "https://files.pythonhosted.org/packages/84/67/6db6dff1ebc8965fd7661498aea0da5d7301074b85bba8606a28f47ede4d/black-25.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9101ee58ddc2442199a25cb648d46ba22cd580b00ca4b44234a324e3ec7a0f7e", size = 1655619, upload-time = "2025-09-19T00:30:49.241Z" },
-    { url = "https://files.pythonhosted.org/packages/10/10/3faef9aa2a730306cf469d76f7f155a8cc1f66e74781298df0ba31f8b4c8/black-25.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:77e7060a00c5ec4b3367c55f39cf9b06e68965a4f2e61cecacd6d0d9b7ec945a", size = 1342481, upload-time = "2025-09-19T00:31:29.625Z" },
-    { url = "https://files.pythonhosted.org/packages/48/99/3acfea65f5e79f45472c45f87ec13037b506522719cd9d4ac86484ff51ac/black-25.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0172a012f725b792c358d57fe7b6b6e8e67375dd157f64fa7a3097b3ed3e2175", size = 1742165, upload-time = "2025-09-19T00:34:10.402Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/18/799285282c8236a79f25d590f0222dbd6850e14b060dfaa3e720241fd772/black-25.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3bec74ee60f8dfef564b573a96b8930f7b6a538e846123d5ad77ba14a8d7a64f", size = 1581259, upload-time = "2025-09-19T00:32:49.685Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ce/883ec4b6303acdeca93ee06b7622f1fa383c6b3765294824165d49b1a86b/black-25.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b756fc75871cb1bcac5499552d771822fd9db5a2bb8db2a7247936ca48f39831", size = 1655583, upload-time = "2025-09-19T00:30:44.505Z" },
-    { url = "https://files.pythonhosted.org/packages/21/17/5c253aa80a0639ccc427a5c7144534b661505ae2b5a10b77ebe13fa25334/black-25.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:846d58e3ce7879ec1ffe816bb9df6d006cd9590515ed5d17db14e17666b2b357", size = 1343428, upload-time = "2025-09-19T00:32:13.839Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/46/863c90dcd3f9d41b109b7f19032ae0db021f0b2a81482ba0a1e28c84de86/black-25.9.0-py3-none-any.whl", hash = "sha256:474b34c1342cdc157d307b56c4c65bce916480c4a8f6551fdc6bf9b486a7c4ae", size = 203363, upload-time = "2025-09-19T00:27:35.724Z" },
 ]
 
 [[package]]
@@ -422,18 +381,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
 ]
 
 [[package]]
@@ -798,33 +745,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
-]
-
-[[package]]
-name = "flake8-bugbear"
-version = "25.10.21"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "flake8" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/54/0f6e431adbc67fd420540e386cb20b57e73e8aeb393f0ae2311e91b4548f/flake8_bugbear-25.10.21.tar.gz", hash = "sha256:2876afcaed8bfb3464cf33e3ec42cc3bec0a004165b84400dc3392b0547c2714", size = 83080, upload-time = "2025-10-22T01:27:03.63Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/0e/8ba976f7d477cad69cc7af08dc7b0163181a5e19a82fe721f954e369c067/flake8_bugbear-25.10.21-py3-none-any.whl", hash = "sha256:f1c5654f9d9d3e62e90da1f0335551fdbc565c51749713177dbcfb9edb105405", size = 37257, upload-time = "2025-10-22T01:27:02.105Z" },
-]
-
-[[package]]
 name = "fonttools"
 version = "4.60.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1033,15 +953,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/d0/274fbf7b0b12643cbbc001ce13e6a5b1607ac4929d1b11c72460152c9fc3/ipython-8.37.0-py3-none-any.whl", hash = "sha256:ed87326596b878932dbcb171e3e698845434d8c61b8d8cd474bf663041a9dcf2", size = 831864, upload-time = "2025-05-31T16:39:06.38Z" },
-]
-
-[[package]]
-name = "isort"
-version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", size = 805049, upload-time = "2025-10-11T13:30:59.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", size = 94672, upload-time = "2025-10-11T13:30:57.665Z" },
 ]
 
 [[package]]
@@ -1496,15 +1407,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1532,15 +1434,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -1865,15 +1758,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
-]
-
-[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2069,30 +1953,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
 ]
 
 [[package]]
@@ -2150,15 +2016,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/c2/dbadcdddb412a267585459142bfd7cc241e6276db69339353ae6e241ab2b/pytokens-0.2.0.tar.gz", hash = "sha256:532d6421364e5869ea57a9523bf385f02586d4662acbcc0342afd69511b4dd43", size = 15368, upload-time = "2025-10-15T08:02:42.738Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/5a/c269ea6b348b6f2c32686635df89f32dbe05df1088dd4579302a6f8f99af/pytokens-0.2.0-py3-none-any.whl", hash = "sha256:74d4b318c67f4295c13782ddd9abcb7e297ec5630ad060eb90abf7ebbefe59f8", size = 12038, upload-time = "2025-10-15T08:02:41.694Z" },
 ]
 
 [[package]]
@@ -2522,6 +2379,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/f9/ce43dbe62767432273ed2584cef71fef8411bddfb64125d4c19128015018/rpds_py-0.28.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:6aa1bfce3f83baf00d9c5fcdbba93a3ab79958b4c7d7d1f55e7fe68c20e63912", size = 561530, upload-time = "2025-10-22T22:24:22.958Z" },
     { url = "https://files.pythonhosted.org/packages/46/c9/ffe77999ed8f81e30713dd38fd9ecaa161f28ec48bb80fa1cd9118399c27/rpds_py-0.28.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:7b0f9dceb221792b3ee6acb5438eb1f02b0cb2c247796a72b016dcc92c6de829", size = 585453, upload-time = "2025-10-22T22:24:24.779Z" },
     { url = "https://files.pythonhosted.org/packages/ed/d2/4a73b18821fd4669762c855fd1f4e80ceb66fb72d71162d14da58444a763/rpds_py-0.28.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:5d0145edba8abd3db0ab22b5300c99dc152f5c9021fab861be0f0544dc3cbc5f", size = 552199, upload-time = "2025-10-22T22:24:26.54Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/34/8218a19b2055b80601e8fd201ec723c74c7fe1ca06d525a43ed07b6d8e85/ruff-0.14.2.tar.gz", hash = "sha256:98da787668f239313d9c902ca7c523fe11b8ec3f39345553a51b25abc4629c96", size = 5539663, upload-time = "2025-10-23T19:37:00.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/dd/23eb2db5ad9acae7c845700493b72d3ae214dce0b226f27df89216110f2b/ruff-0.14.2-py3-none-linux_armv6l.whl", hash = "sha256:7cbe4e593505bdec5884c2d0a4d791a90301bc23e49a6b1eb642dd85ef9c64f1", size = 12533390, upload-time = "2025-10-23T19:36:18.044Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/8c/5f9acff43ddcf3f85130d0146d0477e28ccecc495f9f684f8f7119b74c0d/ruff-0.14.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8d54b561729cee92f8d89c316ad7a3f9705533f5903b042399b6ae0ddfc62e11", size = 12887187, upload-time = "2025-10-23T19:36:22.664Z" },
+    { url = "https://files.pythonhosted.org/packages/99/fa/047646491479074029665022e9f3dc6f0515797f40a4b6014ea8474c539d/ruff-0.14.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5c8753dfa44ebb2cde10ce5b4d2ef55a41fb9d9b16732a2c5df64620dbda44a3", size = 11925177, upload-time = "2025-10-23T19:36:24.778Z" },
+    { url = "https://files.pythonhosted.org/packages/15/8b/c44cf7fe6e59ab24a9d939493a11030b503bdc2a16622cede8b7b1df0114/ruff-0.14.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d0bbeffb8d9f4fccf7b5198d566d0bad99a9cb622f1fc3467af96cb8773c9e3", size = 12358285, upload-time = "2025-10-23T19:36:26.979Z" },
+    { url = "https://files.pythonhosted.org/packages/45/01/47701b26254267ef40369aea3acb62a7b23e921c27372d127e0f3af48092/ruff-0.14.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7047f0c5a713a401e43a88d36843d9c83a19c584e63d664474675620aaa634a8", size = 12303832, upload-time = "2025-10-23T19:36:29.192Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5c/ae7244ca4fbdf2bee9d6405dcd5bc6ae51ee1df66eb7a9884b77b8af856d/ruff-0.14.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bf8d2f9aa1602599217d82e8e0af7fd33e5878c4d98f37906b7c93f46f9a839", size = 13036995, upload-time = "2025-10-23T19:36:31.861Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4c/0860a79ce6fd4c709ac01173f76f929d53f59748d0dcdd662519835dae43/ruff-0.14.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1c505b389e19c57a317cf4b42db824e2fca96ffb3d86766c1c9f8b96d32048a7", size = 14512649, upload-time = "2025-10-23T19:36:33.915Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7f/d365de998069720a3abfc250ddd876fc4b81a403a766c74ff9bde15b5378/ruff-0.14.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a307fc45ebd887b3f26b36d9326bb70bf69b01561950cdcc6c0bdf7bb8e0f7cc", size = 14088182, upload-time = "2025-10-23T19:36:36.983Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ea/d8e3e6b209162000a7be1faa41b0a0c16a133010311edc3329753cc6596a/ruff-0.14.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:61ae91a32c853172f832c2f40bd05fd69f491db7289fb85a9b941ebdd549781a", size = 13599516, upload-time = "2025-10-23T19:36:39.208Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ea/c7810322086db68989fb20a8d5221dd3b79e49e396b01badca07b433ab45/ruff-0.14.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1967e40286f63ee23c615e8e7e98098dedc7301568bd88991f6e544d8ae096", size = 13272690, upload-time = "2025-10-23T19:36:41.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/39/10b05acf8c45786ef501d454e00937e1b97964f846bf28883d1f9619928a/ruff-0.14.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2877f02119cdebf52a632d743a2e302dea422bfae152ebe2f193d3285a3a65df", size = 13496497, upload-time = "2025-10-23T19:36:43.61Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a1/1f25f8301e13751c30895092485fada29076e5e14264bdacc37202e85d24/ruff-0.14.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e681c5bc777de5af898decdcb6ba3321d0d466f4cb43c3e7cc2c3b4e7b843a05", size = 12266116, upload-time = "2025-10-23T19:36:45.625Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/0029bfc9ce16ae78164e6923ef392e5f173b793b26cc39aa1d8b366cf9dc/ruff-0.14.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e21be42d72e224736f0c992cdb9959a2fa53c7e943b97ef5d081e13170e3ffc5", size = 12281345, upload-time = "2025-10-23T19:36:47.618Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ab/ece7baa3c0f29b7683be868c024f0838770c16607bea6852e46b202f1ff6/ruff-0.14.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b8264016f6f209fac16262882dbebf3f8be1629777cf0f37e7aff071b3e9b92e", size = 12629296, upload-time = "2025-10-23T19:36:49.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7f/638f54b43f3d4e48c6a68062794e5b367ddac778051806b9e235dfb7aa81/ruff-0.14.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5ca36b4cb4db3067a3b24444463ceea5565ea78b95fe9a07ca7cb7fd16948770", size = 13371610, upload-time = "2025-10-23T19:36:51.882Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/35/3654a973ebe5b32e1fd4a08ed2d46755af7267da7ac710d97420d7b8657d/ruff-0.14.2-py3-none-win32.whl", hash = "sha256:41775927d287685e08f48d8eb3f765625ab0b7042cc9377e20e64f4eb0056ee9", size = 12415318, upload-time = "2025-10-23T19:36:53.961Z" },
+    { url = "https://files.pythonhosted.org/packages/71/30/3758bcf9e0b6a4193a6f51abf84254aba00887dfa8c20aba18aa366c5f57/ruff-0.14.2-py3-none-win_amd64.whl", hash = "sha256:0df3424aa5c3c08b34ed8ce099df1021e3adaca6e90229273496b839e5a7e1af", size = 13565279, upload-time = "2025-10-23T19:36:56.578Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/5d/aa883766f8ef9ffbe6aa24f7192fb71632f31a30e77eb39aa2b0dc4290ac/ruff-0.14.2-py3-none-win_arm64.whl", hash = "sha256:ea9d635e83ba21569fbacda7e78afbfeb94911c9434aff06192d9bc23fd5495a", size = 12554956, upload-time = "2025-10-23T19:36:58.714Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
  ## Description

  Migrated the repository’s formatting and linting workflow from Black/flake8/isort to Ruff. Added Ruff configuration to pyproject.toml,
  switched automation (pre-commit, Nox, Makefile) to Ruff-based commands, updated contributor guidance, and reformatted the codebase with Ruff’s
  formatter.

  ## Motivation and Context

  Unifies formatting and linting under a single tool, simplifying the developer workflow while preserving the previous linting rules. Ensures
  contributors follow the updated tooling guidance and keeps automation in sync with the new setup.

  ## How Has This Been Tested?

  - uv sync
  - uv run ruff format bask tests noxfile.py
  - uv run ruff check bask tests noxfile.py
  - make lint

  ## Does this close/impact existing issues?

  N/A

  ## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:

  - [x] My code follows the code style of this project.
  - [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
  - [ ] I have added tests to cover my changes.